### PR TITLE
Feature Conqueso API

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -109,8 +109,11 @@ conqueso.frontend.ips=10.0.0.1,10.0.0.2
 PUT and POST requests return an empty body and a 200 (OK) response code. They
 don't create or update any properties internally.
 
+OPTIONS requests return an empty body and a 200 (OK) response code. They include
+an `Allow: GET, POST, PUT, OPTIONS` header.
+
 Any other type of request returns a 405 (Method Not Allowed) response code and
-includes an `Allow: GET, PUT, POST` header.
+includes an `Allow: GET, POST, PUT, OPTIONS` header.
 
 ## Formatted JSON output ##
 

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const HTTP_OK = 200;
+const HTTP_METHOD_NOT_ALLOWED = 405;
 
 /**
  * Conqueso compatible API
@@ -14,6 +15,12 @@ function Conqueso(app) {
 
   app.put('/v1/conqueso*', (req, res) => {
     res.status(HTTP_OK).end();
+  });
+
+  app.delete('/v1/conqueso*', (req, res) => {
+    res.set('Allow', 'POST,PUT');
+    res.status(HTTP_METHOD_NOT_ALLOWED);
+    res.end();
   });
 }
 

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -18,13 +18,13 @@ function Conqueso(app) {
   });
 
   app.options('/v1/conqueso*', (req, res) => {
-    res.set('Allow', 'POST,PUT');
+    res.set('Allow', 'POST,PUT,OPTIONS');
     res.status(HTTP_OK);
     res.end();
   });
 
-  app.delete('/v1/conqueso*', (req, res) => {
-    res.set('Allow', 'POST,PUT');
+  app.all('/v1/conqueso*', (req, res) => {
+    res.set('Allow', 'POST,PUT,OPTIONS');
     res.status(HTTP_METHOD_NOT_ALLOWED);
     res.end();
   });

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -9,6 +9,12 @@ const HTTP_METHOD_NOT_ALLOWED = 405;
  * @param {Express.App} app
  */
 function Conqueso(app) {
+  app.get('/v1/conqueso*', (req, res) => {
+    res.set('Content-Type', 'text/plain')
+    res.status(HTTP_OK);
+    res.end();
+  });
+
   app.post('/v1/conqueso*', (req, res) => {
     res.status(HTTP_OK).end();
   });

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -11,6 +11,10 @@ function Conqueso(app) {
   app.post('/v1/conqueso*', (req, res) => {
     res.status(HTTP_OK).end();
   });
+
+  app.put('/v1/conqueso*', (req, res) => {
+    res.status(HTTP_OK).end();
+  });
 }
 
 exports.attach = Conqueso;

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -7,8 +7,9 @@ const HTTP_METHOD_NOT_ALLOWED = 405;
  * Conqueso compatible API
  *
  * @param {Express.App} app
+ * @param {Storage} storage
  */
-function Conqueso(app) {
+function Conqueso(app, storage) {
   const route = app.route('/v1/conqueso*');
   const allowedMethods = 'GET,POST,PUT,OPTIONS';
 
@@ -18,10 +19,28 @@ function Conqueso(app) {
     res.end();
   }
 
+  /**
+   * Format the given data as Java properites
+   *
+   * @param {Object} data
+   * @return {String}
+   */
+  function makeJavaProperties(data) {
+    const results = [];
+
+    for (const key in data) {
+      if (data.hasOwnProperty(key)) {
+        results.push(key + '=' + data[key]);
+      }
+    }
+
+    return results.join('\n');
+  }
+
   route.get((req, res) => {
     res.set('Content-Type', 'text/plain');
     res.status(HTTP_OK);
-    res.end();
+    res.end(makeJavaProperties(storage.properties));
   });
 
   // Express defaults to using the GET route for HEAD requests.

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const HTTP_OK = 200;
+
+/**
+ * Conqueso compatible API
+ *
+ * @param {Express.App} app
+ */
+function Conqueso(app) {
+  app.post('/v1/conqueso*', (req, res) => {
+    res.status(HTTP_OK).end();
+  });
+}
+
+exports.attach = Conqueso;

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -17,6 +17,12 @@ function Conqueso(app) {
     res.status(HTTP_OK).end();
   });
 
+  app.options('/v1/conqueso*', (req, res) => {
+    res.set('Allow', 'POST,PUT');
+    res.status(HTTP_OK);
+    res.end();
+  });
+
   app.delete('/v1/conqueso*', (req, res) => {
     res.set('Allow', 'POST,PUT');
     res.status(HTTP_METHOD_NOT_ALLOWED);

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -9,35 +9,42 @@ const HTTP_METHOD_NOT_ALLOWED = 405;
  * @param {Express.App} app
  */
 function Conqueso(app) {
+  const route = app.route('/v1/conqueso*');
+  const allowedMethods = 'GET,POST,PUT,OPTIONS';
+
   function methodNotAllowed(req, res) {
-    res.set('Allow', 'POST,PUT,OPTIONS');
+    res.set('Allow', allowedMethods);
     res.status(HTTP_METHOD_NOT_ALLOWED);
     res.end();
   }
 
-  const route = app.route('/v1/conqueso*');
-
   route.get((req, res) => {
-    res.set('Content-Type', 'text/plain')
+    res.set('Content-Type', 'text/plain');
     res.status(HTTP_OK);
     res.end();
   });
 
+  // Express defaults to using the GET route for HEAD requests.
+  // So we need to explicitly reject HEAD request.
+  route.head(methodNotAllowed);
+
   route.post((req, res) => {
-    res.status(HTTP_OK).end();
+    res.status(HTTP_OK);
+    res.end();
   });
 
   route.put((req, res) => {
-    res.status(HTTP_OK).end();
-  });
-
-  route.options((req, res) => {
-    res.set('Allow', 'POST,PUT,OPTIONS');
     res.status(HTTP_OK);
     res.end();
   });
 
-  route.head(methodNotAllowed);
+  route.options((req, res) => {
+    res.set('Allow', allowedMethods);
+    res.status(HTTP_OK);
+    res.end();
+  });
+
+  // Reject anything else e.g. DELETE, TRACE, etc.
   route.all(methodNotAllowed);
 }
 

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -9,31 +9,36 @@ const HTTP_METHOD_NOT_ALLOWED = 405;
  * @param {Express.App} app
  */
 function Conqueso(app) {
-  app.get('/v1/conqueso*', (req, res) => {
+  function methodNotAllowed(req, res) {
+    res.set('Allow', 'POST,PUT,OPTIONS');
+    res.status(HTTP_METHOD_NOT_ALLOWED);
+    res.end();
+  }
+
+  const route = app.route('/v1/conqueso*');
+
+  route.get((req, res) => {
     res.set('Content-Type', 'text/plain')
     res.status(HTTP_OK);
     res.end();
   });
 
-  app.post('/v1/conqueso*', (req, res) => {
+  route.post((req, res) => {
     res.status(HTTP_OK).end();
   });
 
-  app.put('/v1/conqueso*', (req, res) => {
+  route.put((req, res) => {
     res.status(HTTP_OK).end();
   });
 
-  app.options('/v1/conqueso*', (req, res) => {
+  route.options((req, res) => {
     res.set('Allow', 'POST,PUT,OPTIONS');
     res.status(HTTP_OK);
     res.end();
   });
 
-  app.all('/v1/conqueso*', (req, res) => {
-    res.set('Allow', 'POST,PUT,OPTIONS');
-    res.status(HTTP_METHOD_NOT_ALLOWED);
-    res.end();
-  });
+  route.head(methodNotAllowed);
+  route.all(methodNotAllowed);
 }
 
 exports.attach = Conqueso;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "lint": "eslint lib/**"
+    "lint": "eslint lib/** test/**"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "eslint-plugin-rapid7": "^5.0.1",
     "eslint-plugin-react": "^3.14.0",
     "mocha": "^2.3.4",
-    "should": "^8.1.1"
+    "should": "^8.1.1",
+    "supertest": "^1.2.0"
   },
   "dependencies": {
     "aws-sdk": "^2.2.28",

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+'use strict';
+
+const testServerPort = 3000;
+
+/**
+ * Create a new Express server for testing
+ *
+ * @return {http.Server}
+ */
+function makeServer() {
+  const app = require('express')();
+
+  require('../lib/control/v1/conqueso').attach(app);
+  return app.listen(testServerPort);
+}
+
+describe('Conqueso API v1', () => {
+  let server = null;
+
+  beforeEach(() => {
+    server = makeServer();
+  });
+
+  afterEach((done) => {
+    server.close(done);
+  });
+});

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -4,7 +4,10 @@
 const request = require('supertest');
 
 const testServerPort = 3000;
+
 const HTTP_OK = 200;
+const HTTP_METHOD_NOT_ALLOWED = 405;
+
 const conquesoProperties = {
   "instanceMetaData": {
     "meta.property.1": "songs you've never heard of",
@@ -53,5 +56,12 @@ describe('Conqueso API v1', () => {
       .put('/v1/conqueso/api/roles/search/properties')
       .send(conquesoProperties)
       .expect(HTTP_OK, '', done);
+  });
+
+  it('rejects DELETE requests', (done) => {
+    request(server)
+      .delete('/v1/conqueso')
+      .expect('Allow', 'POST,PUT')
+      .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
   });
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -5,6 +5,18 @@ const request = require('supertest');
 
 const testServerPort = 3000;
 const HTTP_OK = 200;
+const conquesoProperties = {
+  "instanceMetaData": {
+    "meta.property.1": "songs you've never heard of",
+    "meta.property.2": "artisanal cream cheese"
+  },
+  "properties": [{
+    "name": "hipster-mode-enabled",
+    "value": "true",
+    "type": "BOOLEAN",
+    "description": "Are you wearing skinny jeans?"
+  }]
+}
 
 /**
  * Create a new Express server for testing
@@ -30,22 +42,16 @@ describe('Conqueso API v1', () => {
   });
 
   it('acknowledges POST requests', (done) => {
-    const properties = {
-      "instanceMetaData": {
-        "meta.property.1": "songs you've never heard of",
-        "meta.property.2": "artisanal cream cheese"
-      },
-      "properties": [{
-        "name": "hipster-mode-enabled",
-        "value": "true",
-        "type": "BOOLEAN",
-        "description": "Are you wearing skinny jeans?"
-      }]
-    }
-
     request(server)
       .post('/v1/conqueso/api/roles/search/properties')
-      .send(properties)
+      .send(conquesoProperties)
+      .expect(HTTP_OK, '', done);
+  });
+
+  it('acknowledges PUT requests', (done) => {
+    request(server)
+      .put('/v1/conqueso/api/roles/search/properties')
+      .send(conquesoProperties)
       .expect(HTTP_OK, '', done);
   });
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -61,14 +61,28 @@ describe('Conqueso API v1', () => {
   it('acknowledges OPTIONS requests', (done) => {
     request(server)
       .options('/v1/conqueso')
-      .expect('Allow', 'POST,PUT')
+      .expect('Allow', 'POST,PUT,OPTIONS')
       .expect(HTTP_OK, '', done);
   });
 
   it('rejects DELETE requests', (done) => {
     request(server)
       .delete('/v1/conqueso')
-      .expect('Allow', 'POST,PUT')
+      .expect('Allow', 'POST,PUT,OPTIONS')
+      .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
+  });
+
+  it('rejects TRACE requests', (done) => {
+    request(server)
+      .trace('/v1/conqueso')
+      .expect('Allow', 'POST,PUT,OPTIONS')
+      .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
+  });
+
+  it('rejects HEAD requests', (done) => {
+    request(server)
+      .head('/v1/conqueso')
+      .expect('Allow', 'POST,PUT,OPTIONS')
       .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
   });
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -1,7 +1,10 @@
 /* eslint-env mocha */
 'use strict';
 
+const request = require('supertest');
+
 const testServerPort = 3000;
+const HTTP_OK = 200;
 
 /**
  * Create a new Express server for testing
@@ -24,5 +27,25 @@ describe('Conqueso API v1', () => {
 
   afterEach((done) => {
     server.close(done);
+  });
+
+  it('acknowledges POST requests', (done) => {
+    const properties = {
+      "instanceMetaData": {
+        "meta.property.1": "songs you've never heard of",
+        "meta.property.2": "artisanal cream cheese"
+      },
+      "properties": [{
+        "name": "hipster-mode-enabled",
+        "value": "true",
+        "type": "BOOLEAN",
+        "description": "Are you wearing skinny jeans?"
+      }]
+    }
+
+    request(server)
+      .post('/v1/conqueso/api/roles/search/properties')
+      .send(properties)
+      .expect(HTTP_OK, '', done);
   });
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -9,17 +9,17 @@ const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
 
 const conquesoProperties = {
-  "instanceMetaData": {
-    "meta.property.1": "songs you've never heard of",
-    "meta.property.2": "artisanal cream cheese"
+  instanceMetaData: {
+    'meta.property.1': 'songs you have never heard of',
+    'meta.property.2': 'artisanal cream cheese'
   },
-  "properties": [{
-    "name": "hipster-mode-enabled",
-    "value": "true",
-    "type": "BOOLEAN",
-    "description": "Are you wearing skinny jeans?"
+  properties: [{
+    name: 'hipster-mode-enabled',
+    value: true,
+    type: 'BOOLEAN',
+    description: 'Are you wearing skinny jeans?'
   }]
-}
+};
 
 /**
  * Create a new Express server for testing

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -68,28 +68,28 @@ describe('Conqueso API v1', () => {
   it('acknowledges OPTIONS requests', (done) => {
     request(server)
       .options('/v1/conqueso')
-      .expect('Allow', 'POST,PUT,OPTIONS')
+      .expect('Allow', 'GET,POST,PUT,OPTIONS')
       .expect(HTTP_OK, '', done);
   });
 
   it('rejects DELETE requests', (done) => {
     request(server)
       .delete('/v1/conqueso')
-      .expect('Allow', 'POST,PUT,OPTIONS')
+      .expect('Allow', 'GET,POST,PUT,OPTIONS')
       .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
   });
 
   it('rejects TRACE requests', (done) => {
     request(server)
       .trace('/v1/conqueso')
-      .expect('Allow', 'POST,PUT,OPTIONS')
+      .expect('Allow', 'GET,POST,PUT,OPTIONS')
       .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
   });
 
   it('rejects HEAD requests', (done) => {
     request(server)
       .head('/v1/conqueso')
-      .expect('Allow', 'POST,PUT,OPTIONS')
+      .expect('Allow', 'GET,POST,PUT,OPTIONS')
       .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
   });
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -44,6 +44,13 @@ describe('Conqueso API v1', () => {
     server.close(done);
   });
 
+  it('acknowledges GET requests', (done) => {
+    request(server)
+      .get('/v1/conqueso/api/roles')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(HTTP_OK, '', done);
+  });
+
   it('acknowledges POST requests', (done) => {
     request(server)
       .post('/v1/conqueso/api/roles/search/properties')

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -58,6 +58,13 @@ describe('Conqueso API v1', () => {
       .expect(HTTP_OK, '', done);
   });
 
+  it('acknowledges OPTIONS requests', (done) => {
+    request(server)
+      .options('/v1/conqueso')
+      .expect('Allow', 'POST,PUT')
+      .expect(HTTP_OK, '', done);
+  });
+
   it('rejects DELETE requests', (done) => {
     request(server)
       .delete('/v1/conqueso')

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -13,13 +13,14 @@ const conquesoProperties = {
     'meta.property.1': 'songs you have never heard of',
     'meta.property.2': 'artisanal cream cheese'
   },
-  properties: [{
+  properties: {
     name: 'hipster-mode-enabled',
     value: true,
-    type: 'BOOLEAN',
-    description: 'Are you wearing skinny jeans?'
-  }]
+    type: 'BOOLEAN'
+  }
 };
+
+const javaProperties = 'name=hipster-mode-enabled\nvalue=true\ntype=BOOLEAN';
 
 /**
  * Create a new Express server for testing
@@ -29,7 +30,7 @@ const conquesoProperties = {
 function makeServer() {
   const app = require('express')();
 
-  require('../lib/control/v1/conqueso').attach(app);
+  require('../lib/control/v1/conqueso').attach(app, conquesoProperties);
   return app.listen(testServerPort);
 }
 
@@ -47,8 +48,9 @@ describe('Conqueso API v1', () => {
   it('acknowledges GET requests', (done) => {
     request(server)
       .get('/v1/conqueso/api/roles')
+      .set('Accept', 'text/plain')
       .expect('Content-Type', 'text/plain; charset=utf-8')
-      .expect(HTTP_OK, '', done);
+      .expect(HTTP_OK, javaProperties, done);
   });
 
   it('acknowledges POST requests', (done) => {


### PR DESCRIPTION
This sets up the [Conqueso compatibility layer](https://github.com/rapid7/propsd/blob/feature-conqueso-api/docs/http-api.md#conqueso) for the HTTP API.

The `Conqueso` function assumes it's been provided an instance of the `Storage` class so it has properties to render. My current assumption is that the Storage class takes care of flattening properties, so accessing the `.properties` value returns a POJO of key value pairs.

The HTTP `OPTIONS` method is now supported and the documentation's been updated to reflect that. I'm contemplating supporting `HEAD` as well (since we support `GET`). Though I don't think that's necessary for Conqueso compatibility.