### PR TITLE
Implemented logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,18 @@
+const Winston = require('winston');
+
+function Logger(config) {
+  return new Winston.Logger({
+    level: config.get('log:level'),
+    transports: [
+      new Winston.transports.Console({
+        colorize: true,
+        timestamp: true
+      }),
+      new Winston.transports.File({
+        filename: config.get('log:filename')
+      })
+    ]
+  });
+}
+
+exports.attach = Logger;

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+'use strict';
+const Winston = require('winston');
+
+describe('logging', () => {
+  it('returns a WINSTON object', () => {
+    const config = require('../lib/config');
+    const log = require('../lib/logger').attach(config);
+
+    log.should.be.an.instanceOf(Winston.Logger);
+  });
+});

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,12 +1,44 @@
 /* eslint-env mocha */
 'use strict';
+
+require('should');
+const fs = require('fs');
 const Winston = require('winston');
 
-describe('logging', () => {
-  it('returns a WINSTON object', () => {
-    const config = require('../lib/config');
-    const log = require('../lib/logger').attach(config);
+class ConfigLike {
+  constructor() {
+    this.data = {
+      'log:level': 'info',
+      'log:filename': 'tmp.log'
+    };
+  }
 
+  get(str) {
+    return this.data[str];
+  }
+}
+
+describe('Logging', () => {
+  const config = new ConfigLike();
+  const log = require('../lib/logger').attach(config);
+  const configFile = config.get('log:filename');
+
+  it('returns a WINSTON object', () => {
     log.should.be.an.instanceOf(Winston.Logger);
+  });
+
+  it('sets the log level correctly', () => {
+    log.level.should.be.exactly('info');
+  });
+
+  before((done) => {
+    log.log(config.get('log:level'), 'Test logging message');
+    done();
+  });
+
+  it('writes to the correct file', (done) => {
+    fs.readFileSync(configFile, 'utf8').should.not.be.Error; // eslint-disable-line no-unused-expressions
+    fs.unlinkSync(configFile);
+    done();
   });
 });


### PR DESCRIPTION
The test will fail because it's tightly coupled with a config object that has an [nconf][]-based interface. This PR shouldn't be merged until the `config` object is implemented.

[nconf]: https://github.com/indexzero/nconf