### PR TITLE
Feature storage engine

### DIFF
--- a/docs/class-storage.md
+++ b/docs/class-storage.md
@@ -7,10 +7,6 @@ _In a future version, the Storage module should be able to discover new sources 
 
 ## Interface
 
-### Constructor
-
-The Storage class can be instantiated with an optional `EventEmitter`. If one's provided, "update" events will be emitted to it whenever merged properties are modified.
-
 ### Class Attribute: `properties`
 
 ```

--- a/docs/class-storage.md
+++ b/docs/class-storage.md
@@ -27,6 +27,10 @@ An array of active Source instances
 
 Sources should call the `update` method to notify the Storage class when they have new properties.
 
+### Instance Method: `register(source)`
+
+Sources should register with the Storage class by calling the `register` method. The `register` method takes the source as an argument. Only registered sources' properties will be merged when `update` is called.
+
 ## Class: Storage.Index
 
 A Scheme for defining an ordered set of sources to be managed by the Storage module. This scheme will parse a JSON array of Source definitions:

--- a/docs/class-storage.md
+++ b/docs/class-storage.md
@@ -3,9 +3,13 @@ Class: Storage
 
 The `Storage` module is responsible for managing data sources and merging their properties into a single document in the correct order. In "Version 1", it will use a dedicated S3Watcher to fetch an index object from S3, and add/remove sources accoding to an array defined therein.
 
-_In a future version, the Storage module should be able to discover new sources from fetched objects, removing the need for an out-of-band definition of sources in an index. Instead, the Storage module would initialize its first source(s) from local configuration, and find additional sources recursivly from their own contents._
+_In a future version, the Storage module should be able to discover new sources from fetched objects, removing the need for an out-of-band definition of sources in an index. Instead, the Storage module would initialize its first source(s) from local configuration, and find additional sources recursively from their own contents._
 
 ## Interface
+
+### Constructor
+
+The Storage class can be instantiated with an optional `EventEmitter`. If one's provided, "update" events will be emitted to it whenever merged properties are modified.
 
 ### Class Attribute: `properties`
 
@@ -22,6 +26,10 @@ Storage.sources
 ```
 
 An array of active Source instances
+
+### Instance Method: `update()`
+
+Sources should call the `update` method to notify the Storage class when they have new properties.
 
 ## Class: Storage.Index
 

--- a/docs/class-storage.md
+++ b/docs/class-storage.md
@@ -25,11 +25,11 @@ An array of active Source instances
 
 ### Instance Method: `update()`
 
-Sources should call the `update` method to notify the Storage class when they have new properties.
+The PluginManager calls the `update` method to notify the Storage class when Source instances have updated properites.
 
 ### Instance Method: `register(source)`
 
-Sources should register with the Storage class by calling the `register` method. The `register` method takes the source as an argument. Only registered sources' properties will be merged when `update` is called.
+The PluginManager registers Sources with the Storage class by calling the `register` method. The `register` method takes the source as an argument. Only registered sources' properties will be merged when `update` is called.
 
 ## Class: Storage.Index
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,0 +1,13 @@
+'use strict';
+
+class Storage {
+  /**
+   * The storage engine maintains a deep merged set of properties retrived from
+   * the registered plugins.
+   */
+  constructor() {
+    this.properties = {};
+  }
+}
+
+module.exports = Storage;

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -4,36 +4,42 @@ const EventEmitter = require('events');
 const UPDATE_TIMEOUT_MS = 500;
 
 /**
+ * Check to if the given value is mergable.
+ *
+ * @param {*} value
+ *
+ * @return {Boolean}  Returns true if the object can be merged, false otherwise.
+ */
+function canMerge(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
  * Perform a deep merge of objects based on key.
  * Warning! Destination is modified in place.
  *
  * @param {Object} source       Object from which keys are copied out of
  * @param {Object} destination  Object from which keys are copied into
- *
- * @return {Object}             Reference to destination
  */
 function merge(source, destination) {
-  if (source instanceof Array && destination instanceof Array) {
-    return destination.concat(source);
-  }
+  if (canMerge(source)) {
+    for (const key in source) {
+      if (source.hasOwnProperty(key)) {
+        const sourceValue = source[key];
+        const destinationValue = destination[key];
 
-  // We're deep merging objects in place, so reassignment is expected.
-  /* eslint-disable no-param-reassign */
-  if (source instanceof Object) {
-    Object.keys(source).forEach((key) => {
-      if (source[key] !== null && !(source[key] instanceof Function) && source[key] instanceof Object) {
-        if (!destination[key] || destination[key].constructor !== source[key].constructor) {
-          destination[key] = new (source[key].constructor)();
+        if (sourceValue !== null && sourceValue !== undefined && !(sourceValue instanceof Function)) {
+          if (canMerge(sourceValue) && canMerge(destinationValue)) {
+            merge(sourceValue, destinationValue);
+          } else {
+            destination[key] = sourceValue; // eslint-disable-line no-param-reassign
+          }
         }
-        destination[key] = merge(source[key], destination[key]);
-      } else {
-        destination[key] = source[key];
       }
-    });
+    }
+  } else {
+    destination = source; // eslint-disable-line no-param-reassign
   }
-
-  /* eslint-enable no-param-reassign */
-  return destination;
 }
 
 class Storage {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -14,6 +14,17 @@ function canMerge(value) {
 }
 
 /**
+ * Check if the given value will overwrite other values during a merge.
+ *
+ * @param {*} value
+ *
+ * @return {Boolean} Returns true if the value will overwrite others, false otherwise.
+ */
+function canOverwriteWith(value) {
+  return value !== null && value !== undefined && !(value instanceof Function);
+}
+
+/**
  * Perform a deep merge of objects based on key.
  * Warning! Destination is modified in place.
  *
@@ -27,7 +38,7 @@ function merge(source, destination) {
         const sourceValue = source[key];
         const destinationValue = destination[key];
 
-        if (sourceValue !== null && sourceValue !== undefined && !(sourceValue instanceof Function)) {
+        if (canOverwriteWith(sourceValue)) {
           if (canMerge(sourceValue) && canMerge(destinationValue)) {
             merge(sourceValue, destinationValue);
           } else {
@@ -36,7 +47,7 @@ function merge(source, destination) {
         }
       }
     }
-  } else {
+  } else if (canOverwriteWith(source)) {
     destination = source; // eslint-disable-line no-param-reassign
   }
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -78,7 +78,9 @@ class Storage {
    * @param {Object} plugin
    */
   register(plugin) {
-    this.sources.push(plugin);
+    if (canMerge(plugin) && plugin.hasOwnProperty('properties')) {
+      this.sources.push(plugin);
+    }
   }
 }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -3,14 +3,48 @@
 const EventEmitter = require('events');
 const UPDATE_TIMEOUT_MS = 500;
 
+/**
+ * Perform a deep merge of objects based on key.
+ * Warning! Destination is modified in place.
+ *
+ * @param {Object} source       Object from which keys are copied out of
+ * @param {Object} destination  Object from which keys are copied into
+ *
+ * @return {Object}             Reference to destination
+ */
+function merge(source, destination) {
+  if (source instanceof Array && destination instanceof Array) {
+    return destination.concat(source);
+  }
+
+  // We're deep merging objects in place, so reassignment is expected.
+  /* eslint-disable no-param-reassign */
+  if (source instanceof Object) {
+    Object.keys(source).forEach((key) => {
+      if (source[key] !== null && !(source[key] instanceof Function) && source[key] instanceof Object) {
+        if (!destination[key] || destination[key].constructor !== source[key].constructor) {
+          destination[key] = new (source[key].constructor)();
+        }
+        destination[key] = merge(source[key], destination[key]);
+      } else {
+        destination[key] = source[key];
+      }
+    });
+  }
+
+  /* eslint-enable no-param-reassign */
+  return destination;
+}
+
 class Storage {
   /**
-   * The storage engine maintains a deep merged set of properties retrived from
+   * The storage engine maintains a merged set of properties retrived from
    * source plugins.
    *
    * @param {EventEmitter} emitter
    */
   constructor(emitter) {
+    this.sources = [];
     this.properties = {};
     this.emitter = emitter || new EventEmitter();
   }
@@ -28,6 +62,9 @@ class Storage {
     this.updateTimeout = setTimeout(() => {
       const properties = Object.create(null);
 
+      this.sources.forEach((source) => {
+        merge(source.properties, properties);
+      });
       this.properties = properties;
 
       /**
@@ -40,6 +77,15 @@ class Storage {
 
       delete this.updateTimeout;
     }, UPDATE_TIMEOUT_MS);
+  }
+
+  /**
+   * Register a named source plugin.
+   *
+   * @param {Object} plugin
+   */
+  register(plugin) {
+    this.sources.push(plugin);
   }
 }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -67,10 +67,7 @@ class Storage {
     const properties = Object.create(null);
 
     this.sources.forEach((source) => {
-      // Marshalling forces the pulgin's properties to merge as JSON.
-      const marshalledProperties = JSON.parse(JSON.stringify(source.properties));
-
-      merge(marshalledProperties, properties);
+      merge(source.properties, properties);
     });
     this.properties = properties;
   }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events');
+const UPDATE_TIMEOUT_MS = 500;
 
 class Storage {
   /**
@@ -20,16 +21,25 @@ class Storage {
    * @fires Storage#update
    */
   update() {
-    /**
-     * Update event.
-     *
-     * @event Storage#update
-     * @type {object}
-     */
-    const properties = Object.create(null);
+    if (this.updateTimeout) {
+      return;
+    }
 
-    this.properties = properties;
-    this.emitter.emit('update', properties);
+    this.updateTimeout = setTimeout(() => {
+      const properties = Object.create(null);
+
+      this.properties = properties;
+
+      /**
+       * Update event.
+       *
+       * @event Storage#update
+       * @type {object}
+       */
+      this.emitter.emit('update', properties);
+
+      delete this.updateTimeout;
+    }, UPDATE_TIMEOUT_MS);
   }
 }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -56,7 +56,7 @@ class Storage {
   /**
    * The storage engine maintains a merged set of properties retrived from
    * source plugins. An optional EventEmitter can be provided. When properties
-   * change an "update" event will fire on the emitter with the new properites.
+   * change an "update" event will fire on the emitter with the new properties.
    *
    * @param {EventEmitter} emitter
    */

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const UPDATE_TIMEOUT_MS = 500;
-
 /**
  * Check to if the given value is mergable.
  *
@@ -55,47 +53,23 @@ function merge(source, destination) {
 class Storage {
   /**
    * The storage engine maintains a merged set of properties retrived from
-   * source plugins. An optional EventEmitter can be provided. When properties
-   * change an "update" event will fire on the emitter with the new properties.
-   *
-   * @param {EventEmitter} emitter
+   * source plugins.
    */
-  constructor(emitter) {
-    this.properties = {};
+  constructor() {
+    this.properties = Object.create(null);
     this.sources = [];
-    this._emitter = emitter;
   }
 
   /**
    * Update cached properties by merging values from source plugins.
-   *
-   * @fires Storage#update
    */
   update() {
-    if (this._updateTimeout) {
-      return;
-    }
+    const properties = Object.create(null);
 
-    this._updateTimeout = setTimeout(() => {
-      const properties = Object.create(null);
-
-      this.sources.forEach((source) => {
-        merge(source.properties, properties);
-      });
-      this.properties = properties;
-
-      /**
-       * Update event.
-       *
-       * @event Storage#update
-       * @type {object}
-       */
-      if (this._emitter) {
-        this._emitter.emit('update', properties);
-      }
-
-      delete this._updateTimeout;
-    }, UPDATE_TIMEOUT_MS);
+    this.sources.forEach((source) => {
+      merge(source.properties, properties);
+    });
+    this.properties = properties;
   }
 
   /**

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -62,7 +62,7 @@ class Storage {
    */
   constructor(emitter) {
     this.properties = {};
-    this._sources = [];
+    this.sources = [];
     this._emitter = emitter;
   }
 
@@ -79,7 +79,7 @@ class Storage {
     this._updateTimeout = setTimeout(() => {
       const properties = Object.create(null);
 
-      this._sources.forEach((source) => {
+      this.sources.forEach((source) => {
         merge(source.properties, properties);
       });
       this.properties = properties;
@@ -104,7 +104,7 @@ class Storage {
    * @param {Object} plugin
    */
   register(plugin) {
-    this._sources.push(plugin);
+    this.sources.push(plugin);
   }
 }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const EventEmitter = require('events');
 const UPDATE_TIMEOUT_MS = 500;
 
 /**
@@ -45,14 +44,15 @@ function merge(source, destination) {
 class Storage {
   /**
    * The storage engine maintains a merged set of properties retrived from
-   * source plugins.
+   * source plugins. An optional EventEmitter can be provided. When properties
+   * change an "update" event will fire on the emitter with the new properites.
    *
    * @param {EventEmitter} emitter
    */
   constructor(emitter) {
-    this.sources = [];
     this.properties = {};
-    this.emitter = emitter || new EventEmitter();
+    this._sources = [];
+    this._emitter = emitter;
   }
 
   /**
@@ -61,14 +61,14 @@ class Storage {
    * @fires Storage#update
    */
   update() {
-    if (this.updateTimeout) {
+    if (this._updateTimeout) {
       return;
     }
 
-    this.updateTimeout = setTimeout(() => {
+    this._updateTimeout = setTimeout(() => {
       const properties = Object.create(null);
 
-      this.sources.forEach((source) => {
+      this._sources.forEach((source) => {
         merge(source.properties, properties);
       });
       this.properties = properties;
@@ -79,9 +79,11 @@ class Storage {
        * @event Storage#update
        * @type {object}
        */
-      this.emitter.emit('update', properties);
+      if (this._emitter) {
+        this._emitter.emit('update', properties);
+      }
 
-      delete this.updateTimeout;
+      delete this._updateTimeout;
     }, UPDATE_TIMEOUT_MS);
   }
 
@@ -91,7 +93,7 @@ class Storage {
    * @param {Object} plugin
    */
   register(plugin) {
-    this.sources.push(plugin);
+    this._sources.push(plugin);
   }
 }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -67,7 +67,10 @@ class Storage {
     const properties = Object.create(null);
 
     this.sources.forEach((source) => {
-      merge(source.properties, properties);
+      // Marshalling forces the pulgin's properties to merge as JSON.
+      const marshalledProperties = JSON.parse(JSON.stringify(source.properties));
+
+      merge(marshalledProperties, properties);
     });
     this.properties = properties;
   }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,12 +1,35 @@
 'use strict';
 
+const EventEmitter = require('events');
+
 class Storage {
   /**
    * The storage engine maintains a deep merged set of properties retrived from
-   * the registered plugins.
+   * source plugins.
+   *
+   * @param {EventEmitter} emitter
    */
-  constructor() {
+  constructor(emitter) {
     this.properties = {};
+    this.emitter = emitter || new EventEmitter();
+  }
+
+  /**
+   * Update cached properties by merging values from source plugins.
+   *
+   * @fires Storage#update
+   */
+  update() {
+    /**
+     * Update event.
+     *
+     * @event Storage#update
+     * @type {object}
+     */
+    const properties = Object.create(null);
+
+    this.properties = properties;
+    this.emitter.emit('update', properties);
   }
 }
 

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -32,4 +32,25 @@ describe('Storage Engine', () => {
 
     storage.update();
   });
+
+  it('prevents update event spam', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+    const updateTimeoutMS = 1000;
+
+    let updateEventCount = 0;
+
+    emitter.on('update', (properties) => {
+      updateEventCount += 1;
+      should(properties).be.empty();
+    });
+
+    storage.update();
+    storage.update();
+
+    setTimeout(() => {
+      assert.equal(updateEventCount, 1, 'Too many Storage#update events sent');
+      done();
+    }, updateTimeoutMS);
+  });
 });

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -2,7 +2,8 @@
 'use strict';
 
 const should = require('should');
-
+const assert = require('assert');
+const EventEmitter = require('events');
 const Storage = require('../lib/storage');
 
 describe('Storage Engine', () => {
@@ -10,6 +11,25 @@ describe('Storage Engine', () => {
     const storage = new Storage();
 
     storage.should.have.property('properties');
-    should(storage.properties).be.empty;
+    should(storage.properties).be.empty();
+  });
+
+  it('fires update events with new properties', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+
+    const updateTimeoutMS = 5000;
+    const updateTimeout = setTimeout(() => {
+      assert(false, 'Storage#update event never fired.');
+      done();
+    }, updateTimeoutMS);
+
+    emitter.on('update', (properties) => {
+      clearTimeout(updateTimeout);
+      should(properties).be.empty();
+      done();
+    });
+
+    storage.update();
   });
 });

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -2,8 +2,6 @@
 'use strict';
 
 const should = require('should');
-const assert = require('assert');
-const EventEmitter = require('events');
 const Storage = require('../lib/storage');
 
 describe('Storage Engine', () => {
@@ -12,46 +10,6 @@ describe('Storage Engine', () => {
 
     storage.should.have.property('properties');
     should(storage.properties).be.empty();
-  });
-
-  it('fires update events with new properties', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
-
-    const updateTimeoutMS = 1000;
-    const updateTimeout = setTimeout(() => {
-      assert(false, 'Storage#update event never fired.');
-      done();
-    }, updateTimeoutMS);
-
-    emitter.on('update', (properties) => {
-      clearTimeout(updateTimeout);
-      should(properties).be.empty();
-      done();
-    });
-
-    storage.update();
-  });
-
-  it('prevents update event spam', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
-    const updateTimeoutMS = 1000;
-
-    let updateEventCount = 0;
-
-    emitter.on('update', (properties) => {
-      updateEventCount += 1;
-      should(properties).be.empty();
-    });
-
-    storage.update();
-    storage.update();
-
-    setTimeout(() => {
-      assert.equal(updateEventCount, 1, 'Too many Storage#update events sent');
-      done();
-    }, updateTimeoutMS);
   });
 
   it('maintains an ordered list of active sources', () => {
@@ -69,9 +27,8 @@ describe('Storage Engine', () => {
     should(storage.sources).eql([source1, source2]);
   });
 
-  it('ignores null when merging properties', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
+  it('ignores null when merging properties', () => {
+    const storage = new Storage();
 
     storage.register({
       properties: {
@@ -85,18 +42,13 @@ describe('Storage Engine', () => {
       }
     });
 
-    emitter.on('update', (properties) => {
-      should(properties).have.property('food');
-      should(properties.food).eql(['tacos', 'peanuts']);
-      done();
-    });
-
     storage.update();
+    should(storage.properties).have.property('food');
+    should(storage.properties.food).eql(['tacos', 'peanuts']);
   });
 
-  it('ignores undefined when merging properties', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
+  it('ignores undefined when merging properties', () => {
+    const storage = new Storage();
 
     storage.register({
       properties: {
@@ -110,18 +62,13 @@ describe('Storage Engine', () => {
       }
     });
 
-    emitter.on('update', (properties) => {
-      should(properties).have.property('food');
-      should(properties.food).eql(['tacos', 'peanuts']);
-      done();
-    });
-
     storage.update();
+    should(storage.properties).have.property('food');
+    should(storage.properties.food).eql(['tacos', 'peanuts']);
   });
 
-  it('ignores Functions when merging properties', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
+  it('ignores Functions when merging properties', () => {
+    const storage = new Storage();
 
     storage.register({
       properties: {
@@ -137,18 +84,13 @@ describe('Storage Engine', () => {
       }
     });
 
-    emitter.on('update', (properties) => {
-      should(properties).have.property('food');
-      should(properties.food).eql(['tacos', 'peanuts']);
-      done();
-    });
-
     storage.update();
+    should(storage.properties).have.property('food');
+    should(storage.properties.food).eql(['tacos', 'peanuts']);
   });
 
-  it('overwrites arrays when merging properties', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
+  it('overwrites arrays when merging properties', () => {
+    const storage = new Storage();
 
     storage.register({
       properties: {
@@ -162,18 +104,13 @@ describe('Storage Engine', () => {
       }
     });
 
-    emitter.on('update', (properties) => {
-      should(properties).have.property('food');
-      should(properties.food).eql(['noodles']);
-      done();
-    });
-
     storage.update();
+    should(storage.properties).have.property('food');
+    should(storage.properties.food).eql(['noodles']);
   });
 
-  it('overwrite JSON types when merging properties', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
+  it('overwrite JSON types when merging properties', () => {
+    const storage = new Storage();
 
     storage.register({
       properties: {
@@ -187,18 +124,13 @@ describe('Storage Engine', () => {
       }
     });
 
-    emitter.on('update', (properties) => {
-      should(properties).have.property('food');
-      should(properties.food).eql('pizza');
-      done();
-    });
-
     storage.update();
+    should(storage.properties).have.property('food');
+    should(storage.properties.food).eql('pizza');
   });
 
-  it('recursive merge when merging properties', (done) => {
-    const emitter = new EventEmitter();
-    const storage = new Storage(emitter);
+  it('recursive merge when merging properties', () => {
+    const storage = new Storage();
 
     storage.register({
       properties: {
@@ -217,12 +149,8 @@ describe('Storage Engine', () => {
       }
     });
 
-    emitter.on('update', (properties) => {
-      should(properties).have.property('food');
-      should(properties.food).eql({likes: 'tacos', dislikes: 'gluten'});
-      done();
-    });
-
     storage.update();
+    should(storage.properties).have.property('food');
+    should(storage.properties.food).eql({likes: 'tacos', dislikes: 'gluten'});
   });
 });

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -1,0 +1,15 @@
+/* eslint-env mocha */
+'use strict';
+
+const should = require('should');
+
+const Storage = require('../lib/storage');
+
+describe('Storage Engine', () => {
+  it('has no properties by default', () => {
+    const storage = new Storage();
+
+    storage.should.have.property('properties');
+    should(storage.properties).be.empty;
+  });
+});

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -69,7 +69,7 @@ describe('Storage Engine', () => {
     should(storage.sources).eql([source1, source2]);
   });
 
-  it('ignores null when merging properites', (done) => {
+  it('ignores null when merging properties', (done) => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);
 
@@ -94,7 +94,7 @@ describe('Storage Engine', () => {
     storage.update();
   });
 
-  it('ignores undefined when merging properites', (done) => {
+  it('ignores undefined when merging properties', (done) => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);
 
@@ -119,7 +119,7 @@ describe('Storage Engine', () => {
     storage.update();
   });
 
-  it('ignores Functions when merging properites', (done) => {
+  it('ignores Functions when merging properties', (done) => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);
 
@@ -146,7 +146,7 @@ describe('Storage Engine', () => {
     storage.update();
   });
 
-  it('overwrites arrays when merging properites', (done) => {
+  it('overwrites arrays when merging properties', (done) => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);
 

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -53,4 +53,104 @@ describe('Storage Engine', () => {
       done();
     }, updateTimeoutMS);
   });
+
+  it('ignores null when merging properites', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+
+    storage.register({
+      properties: null
+    });
+
+    storage.register({
+      properties: {
+        food: ['tacos', 'peanuts']
+      }
+    });
+
+    emitter.on('update', (properties) => {
+      should(properties).have.property('food');
+      should(properties.food).eql(['tacos', 'peanuts']);
+      done();
+    });
+
+    storage.update();
+  });
+
+  it('ignores Functions when merging properites', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+
+    storage.register({
+      properties: () => {
+        return {
+          food: 'cabbage'
+        };
+      }
+    });
+
+    storage.register({
+      properties: {
+        food: ['tacos', 'peanuts']
+      }
+    });
+
+    emitter.on('update', (properties) => {
+      should(properties).have.property('food');
+      should(properties.food).eql(['tacos', 'peanuts']);
+      done();
+    });
+
+    storage.update();
+  });
+
+  it('concatenates arrays when merging properites', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+
+    storage.register({
+      properties: {
+        food: ['tacos', 'peanuts']
+      }
+    });
+
+    storage.register({
+      properties: {
+        food: ['noodles']
+      }
+    });
+
+    emitter.on('update', (properties) => {
+      should(properties).have.property('food');
+      should(properties.food).eql(['tacos', 'peanuts', 'noodles']);
+      done();
+    });
+
+    storage.update();
+  });
+
+  it('lets the last plugin win when merging properties', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+
+    storage.register({
+      properties: {
+        food: ['tacos', 'peanuts']
+      }
+    });
+
+    storage.register({
+      properties: {
+        food: 'pizza'
+      }
+    });
+
+    emitter.on('update', (properties) => {
+      should(properties).have.property('food');
+      should(properties.food).eql('pizza');
+      done();
+    });
+
+    storage.update();
+  });
 });

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -41,7 +41,7 @@ describe('Storage Engine', () => {
     should(storage.sources).eql([]);
   });
 
-  it('merges properites on demand', () => {
+  it('merges properties on demand', () => {
     const storage = new Storage();
 
     storage.register({

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -27,6 +27,20 @@ describe('Storage Engine', () => {
     should(storage.sources).eql([source1, source2]);
   });
 
+  it('merges properites on demand', () => {
+    const storage = new Storage();
+
+    storage.register({
+      properties: {
+        food: 'tacos'
+      }
+    });
+
+    should(storage.properties).not.have.property('food');
+    storage.update();
+    should(storage.properties).have.property('food');
+  });
+
   it('ignores null when merging properties', () => {
     const storage = new Storage();
 

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -181,4 +181,22 @@ describe('Storage Engine', () => {
     should(storage.properties).have.property('food');
     should(storage.properties.food).eql({likes: 'tacos', dislikes: 'gluten'});
   });
+
+  it('copy properties when merging them', () => {
+    const storage = new Storage();
+    const plugin = {
+      properties: {
+        food: 'pizza'
+      }
+    };
+
+    storage.register(plugin);
+    storage.update();
+
+    should(storage.properties.food).eql('pizza');
+    plugin.properties.food = 'tacos';
+    should(storage.properties.food).eql('pizza');
+    storage.update();
+    should(storage.properties.food).eql('tacos');
+  });
 });

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -54,6 +54,21 @@ describe('Storage Engine', () => {
     }, updateTimeoutMS);
   });
 
+  it('maintains an ordered list of active sources', () => {
+    const storage = new Storage();
+    const source1 = {properties: {food: ['tacos', 'peanuts']}};
+    const source2 = {properties: {food: null}};
+
+    should(storage).have.property('sources');
+    should(storage.sources).be.empty();
+
+    storage.register(source1);
+    should(storage.sources).eql([source1]);
+
+    storage.register(source2);
+    should(storage.sources).eql([source1, source2]);
+  });
+
   it('ignores null when merging properites', (done) => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -59,12 +59,39 @@ describe('Storage Engine', () => {
     const storage = new Storage(emitter);
 
     storage.register({
-      properties: null
+      properties: {
+        food: ['tacos', 'peanuts']
+      }
     });
 
     storage.register({
       properties: {
+        food: null
+      }
+    });
+
+    emitter.on('update', (properties) => {
+      should(properties).have.property('food');
+      should(properties.food).eql(['tacos', 'peanuts']);
+      done();
+    });
+
+    storage.update();
+  });
+
+  it('ignores undefined when merging properites', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+
+    storage.register({
+      properties: {
         food: ['tacos', 'peanuts']
+      }
+    });
+
+    storage.register({
+      properties: {
+        food: undefined
       }
     });
 
@@ -82,16 +109,16 @@ describe('Storage Engine', () => {
     const storage = new Storage(emitter);
 
     storage.register({
-      properties: () => {
-        return {
-          food: 'cabbage'
-        };
+      properties: {
+        food: ['tacos', 'peanuts']
       }
     });
 
     storage.register({
       properties: {
-        food: ['tacos', 'peanuts']
+        food: () => {
+          return 'cabbage';
+        }
       }
     });
 
@@ -104,7 +131,7 @@ describe('Storage Engine', () => {
     storage.update();
   });
 
-  it('concatenates arrays when merging properites', (done) => {
+  it('overwrites arrays when merging properites', (done) => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);
 
@@ -122,14 +149,14 @@ describe('Storage Engine', () => {
 
     emitter.on('update', (properties) => {
       should(properties).have.property('food');
-      should(properties.food).eql(['tacos', 'peanuts', 'noodles']);
+      should(properties.food).eql(['noodles']);
       done();
     });
 
     storage.update();
   });
 
-  it('lets the last plugin win when merging properties', (done) => {
+  it('overwrite JSON types when merging properties', (done) => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);
 
@@ -148,6 +175,36 @@ describe('Storage Engine', () => {
     emitter.on('update', (properties) => {
       should(properties).have.property('food');
       should(properties.food).eql('pizza');
+      done();
+    });
+
+    storage.update();
+  });
+
+  it('recursive merge when merging properties', (done) => {
+    const emitter = new EventEmitter();
+    const storage = new Storage(emitter);
+
+    storage.register({
+      properties: {
+        food: {
+          likes: 'pizza'
+        }
+      }
+    });
+
+    storage.register({
+      properties: {
+        food: {
+          likes: 'tacos',
+          dislikes: 'gluten'
+        }
+      }
+    });
+
+    emitter.on('update', (properties) => {
+      should(properties).have.property('food');
+      should(properties.food).eql({likes: 'tacos', dislikes: 'gluten'});
       done();
     });
 

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -18,7 +18,7 @@ describe('Storage Engine', () => {
     const emitter = new EventEmitter();
     const storage = new Storage(emitter);
 
-    const updateTimeoutMS = 5000;
+    const updateTimeoutMS = 1000;
     const updateTimeout = setTimeout(() => {
       assert(false, 'Storage#update event never fired.');
       done();

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -27,6 +27,20 @@ describe('Storage Engine', () => {
     should(storage.sources).eql([source1, source2]);
   });
 
+  it('ignores sources without properties', () => {
+    const storage = new Storage();
+
+    storage.register(null);
+    storage.register(undefined);
+    storage.register(1.0);
+    storage.register('properties');
+    storage.register(() => {});
+    storage.register([]);
+    storage.register({});
+
+    should(storage.sources).eql([]);
+  });
+
   it('merges properites on demand', () => {
     const storage = new Storage();
 


### PR DESCRIPTION
This provides a `Storage` class to manage the collected set of merged properties from plugins. The `Storage#register` function is called to register plugins. When a plugin has updated properties, calling `Storage#update` to let the engine know new properties are available.

The responsibility for registering plugins with the `Storage` class and notifying the `Storage` class when plugins have new properties, is left to up an as of yet undefined `PluginManager`.