### PR TITLE
Fix for the metadata source plugin not playing nice with the storage layer's register method

### DIFF
--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -198,6 +198,7 @@ class Metadata extends EventEmitter {
     this.name = options.name || 'source';
     this._ok = false;
     this._updated = null;
+    this.properties = {};
 
     /**
      * Initialize the metadata-service client
@@ -211,15 +212,6 @@ class Metadata extends EventEmitter {
 
     this.configure(options);
     this.signature = null;
-  }
-
-  /**
-   * The source's properties
-   *
-   * @returns {Object}
-   */
-  get properties() {
-    return this._parser.properties;
   }
 
   /**
@@ -417,6 +409,7 @@ class Metadata extends EventEmitter {
    */
   _update(data) {
     this._parser.update(data);
+    this.properties = this._parser.properties;
     this._updated = new Date();
     this._ok = true;
 


### PR DESCRIPTION
```javascript
// Storage.register
register(plugin) {
  if (canMerge(plugin) && plugin.hasOwnProperty('properties')) {
    this.sources.push(plugin);
  }
}
```
The `Metadata` source can't be registered with the storage layer because getters aren't picked up by `hasOwnProperty()`. We could change the storage layer, but `Object.getOwnPropertyDescriptor()` is inconsistent when the underlying data comes from an object with a different `__proto__`.

It's easier and more consistent to have a properties attribute on the `Metadata` class rather than use a getter.