### PR TITLE
Fix metadata signature bug

### DIFF
--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -327,6 +327,7 @@ class Metadata extends EventEmitter {
     }
 
     this._ok = false;
+    this.signature = null;
 
     Log.info(`Shutting down ${this._type} source ${this.name}`, {
       source: this.name,

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -2,7 +2,7 @@
 /* global Config */
 'use strict';
 
-require('should');
+const should = require('should');
 const Path = require('path');
 const fs = require('fs');
 const winston = require('winston');
@@ -83,6 +83,16 @@ describe('Metadata source plugin', () => {
   it('can only be initialized once', () => {
     this.m.initialize();
     this.m.should.deepEqual(this.m.initialize());
+  });
+
+  it('clears the sha1 signature when it\'s shutdown', (done) => {
+    this.m.on('shutdown', () => {
+      should(this.m.signature).be.null();
+      done();
+    });
+
+    this.m.initialize();
+    this.m.shutdown();
   });
 
   it('doesn\'t update data if the Metadata Service document is the same', (done) => {


### PR DESCRIPTION
This fixes a bug where even if a metadata source plugin instance is shut down it still maintains the sha1 signature of the data which means `update` events won't be emitted if the plugin is started again unless the underlying data changes.