### PR TITLE
Expose type property in source interface

### DIFF
--- a/docs/sources/source-interface.md
+++ b/docs/sources/source-interface.md
@@ -3,26 +3,25 @@
 All source plugins must expose the following:
 
 ## Methods
-1. A constructor that accepts a path to a given resource. That resource can be local or remote as long as the plugin itself understands how to parse the path and retrieve the data. Additional arguments are acceptable as long as the index document contains information to fill in the remaining arguments.
-1. `getName()`: (`string`) Returns a unique name for the plugin instance.
-	
-	In the S3 source, for example, `getName()` returns a string comprised of the plugin type, the resource bucket, and the resource path.
-	
-1. `getType()`: (`string`) Returns the plugin type.
-1. `fetch(callback, args)` Executes the callback with the given `args`. 
+1. A constructor that accepts an object of options. These options are source-specific and should be created based on the source documentation.
 
-	Built-in plugins have a `defaultFetch(options)` method that provides a default callback. For instance, the S3 plugin can be executed simply by calling `s3.fetch()`.
-	
-1. `status()`: (`Object`) Returns the plugin's status.
-1. `shutdown()`: Cleans up any open handles (fs, timer, etc.) the plugin has open.
+1. `Source#configure(params)`
+1. `Source#initialize()`
+1. `Source#status()`: (`Object`) Returns the plugin's status.
+1. `Source#shutdown()`: Cleans up any open handles (fs, timer, etc.) the plugin has open.
+
+## Properties
+1. `Source#interval`: (`Integer`) The interval between execution attempts.
+1. `Source#type`: (`String`) The source type. This is a static value for each source type.
+1. `Source#name`: (`String`) A unique name comprised of `Source#type` and other information, such as the S3 bucket and key.
+1. `Source#properties`: (`Object`) The properties retrieved and parsed from the source's underlying data.
+1. `Source#service`: (`AWS.S3|AWS.MetadataService|Object`) The underlying service that retrieves data.
+
+Specific source types have other exposed properties that are only specific to that plugin. For example, the `Metadata` source exposes `Metadata#signature` which is the sha1 signature of the `Metadata#properties` object used to prevent re-parsing if there's no change to the underlying data.
 
 ## Events
-1. `source-done`: Emitted with:
-	* `type`: (`string`) The source type (see `getType()`)
-	* `name`: (`string`) The source name (see `getName()`)
-	* `data`: (`Object`) The parsed payload returned from the source.
-
-1. `source-err`: Emitted with:
-	* `type`: (`string`) The source type (see `getType()`)
-	* `name`: (`string`) The source name (see `getName()`)
-	* `err`: (`Error`) An instance of `Error` containing information about the error.
+1. `startup`
+1. `shutdown`
+1. `update`: Emitted with an instance of the source plugin.
+1. `no-update`
+1. `error`: Emitted with an instance of `Error` describing what went wrong.

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -194,6 +194,7 @@ class Metadata extends EventEmitter {
     }
 
     this.interval = DEFAULT_INTERVAL;
+    this.type = 'ec2-metadata';
     this._parser = new MetadataParser(options);
     this.name = options.name || 'source';
     this._ok = false;
@@ -221,16 +222,6 @@ class Metadata extends EventEmitter {
    */
   get _running() {
     return !!this._timer;
-  }
-
-  /**
-   * The source type
-   *
-   * @returns {string}
-   * @private
-   */
-  get _type() {
-    return this.constructor.type;
   }
 
   /**
@@ -264,9 +255,9 @@ class Metadata extends EventEmitter {
       return this;
     }
 
-    Log.info(`Initializing ${this._type} source ${this.name}`, {
+    Log.info(`Initializing ${this.type} source ${this.name}`, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
 
     // Initialize state to 'RUNNING'
@@ -280,7 +271,7 @@ class Metadata extends EventEmitter {
 
       Log.debug(`Polling source ${_this.name} for updates`, {
         source: _this.name,
-        type: _this._type
+        type: _this.type
       });
 
       _this._fetch((err, data) => {
@@ -296,7 +287,7 @@ class Metadata extends EventEmitter {
 
         Log.debug(`Polled source ${_this.name} in ${(Date.now() - timer)}ms`, {
           source: _this.name,
-          type: _this._type
+          type: _this.type
         });
 
         if (data) {
@@ -306,7 +297,7 @@ class Metadata extends EventEmitter {
 
         Log.debug(`Source ${_this.name} is up to date`, {
           source: _this.name,
-          type: _this._type
+          type: _this.type
         });
       });
 
@@ -329,9 +320,9 @@ class Metadata extends EventEmitter {
     this._ok = false;
     this.signature = null;
 
-    Log.info(`Shutting down ${this._type} source ${this.name}`, {
+    Log.info(`Shutting down ${this.type} source ${this.name}`, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
 
     clearTimeout(this._timer);
@@ -416,7 +407,7 @@ class Metadata extends EventEmitter {
 
     Log.info('Updated source ' + this.name, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
     this.emit('update', this);
 
@@ -436,7 +427,7 @@ class Metadata extends EventEmitter {
     this._ok = false;
     Log.error(err, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
 
     // Only emit an error event if there are listeners.
@@ -498,7 +489,6 @@ class Metadata extends EventEmitter {
 }
 
 Metadata.version = 'latest';
-Metadata.type = 'ec2-metadata';
 
 /* Export */
 module.exports = Metadata;

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -37,6 +37,7 @@ class S3 extends EventEmitter {
     }
 
     this.interval = DEFAULT_INTERVAL;
+    this.type = 's3';
     this._parser = options.parser || new S3Parser(options);
     this._ok = false;
     this._updated = null;
@@ -63,16 +64,6 @@ class S3 extends EventEmitter {
   }
 
   /**
-   * The source type
-   *
-   * @returns {string}
-   * @private
-   */
-  get _type() {
-    return this.constructor.type;
-  }
-
-  /**
    * @param {Object} params
    * @returns {Boolean}
    */
@@ -91,9 +82,9 @@ class S3 extends EventEmitter {
       return this;
     }
 
-    Log.info(`Initializing ${this._type} source ${this.name}`, {
+    Log.info(`Initializing ${this.type} source ${this.name}`, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
 
     // Initialize state to 'RUNNING'
@@ -107,7 +98,7 @@ class S3 extends EventEmitter {
 
       Log.debug(`Polling source ${_this.name} for updates`, {
         source: _this.name,
-        type: _this._type
+        type: _this.type
       });
 
       _this._fetch((err, data) => {
@@ -123,7 +114,7 @@ class S3 extends EventEmitter {
 
         Log.debug(`Polled source ${_this.name} in ${(Date.now() - timer)}ms`, {
           source: _this.name,
-          type: _this._type
+          type: _this.type
         });
 
         if (data) {
@@ -133,7 +124,7 @@ class S3 extends EventEmitter {
 
         Log.debug(`Source ${_this.name} is up to date`, {
           source: _this.name,
-          type: _this._type
+          type: _this.type
         });
       });
 
@@ -155,9 +146,9 @@ class S3 extends EventEmitter {
 
     this._ok = false;
 
-    Log.info(`Shutting down ${this._type} source ${this.name}`, {
+    Log.info(`Shutting down ${this.type} source ${this.name}`, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
 
     clearTimeout(this._timer);
@@ -194,7 +185,7 @@ class S3 extends EventEmitter {
     this._ok = false;
     Log.error(err, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
 
     // Only emit an error event if there are listeners.
@@ -253,7 +244,7 @@ class S3 extends EventEmitter {
 
     Log.info('Updated source ' + this.name, {
       source: this.name,
-      type: this._type
+      type: this.type
     });
     this.emit('update', this);
 
@@ -278,7 +269,5 @@ class S3 extends EventEmitter {
     return true;
   }
 }
-
-S3.type = 's3';
 
 module.exports = S3;

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -136,6 +136,10 @@ describe('Metadata source plugin', () => {
     this.m.initialize();
   });
 
+  it('identifies as a \'ec2-metadata\' source plugin', () => {
+    this.m.type.should.equal('ec2-metadata');
+  });
+
   after(() => {
     server.start();
   });

--- a/test/s3.js
+++ b/test/s3.js
@@ -188,4 +188,8 @@ describe('S3 source plugin', () => {
     this.s3.initialize();
     this.s3.should.deepEqual(this.s3.initialize());
   });
+
+  it('identifies as a \'s3\' source plugin', () => {
+    this.s3.type.should.equal('s3');
+  });
 });


### PR DESCRIPTION
This is the first pull request that will culminate in the `PluginManager` implementation. The `PluginManager` requires a defined `type` for each source in order to create an instance of the correct source plugin from the index.

This should be an essentially static property per source class. The value of `type` should be reflected in the `_registerSources()` method in the `PluginManager`.