### PR TITLE
Reorganized test suite

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+'use strict';
+
+const Path = require('path');
+const winston = require('winston');
+const server = require('./utils/test-metadata-server');
+
+// Need to disable console logging for these tests to filter out the chaff from meaningful test output
+global.Config = require('../lib/config').load(Path.resolve(__dirname, './data/config.json'));
+global.Log = require('../lib/logger').attach(global.Config);
+global.Log.remove(winston.transports.Console);
+
+before(function globalBefore() {
+  server.start();
+});
+
+after(function globalAfter() {
+  server.stop();
+});

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -5,16 +5,6 @@
 const should = require('should');
 const Path = require('path');
 const fs = require('fs');
-const winston = require('winston');
-
-const server = require('./utils/test-metadata-server');
-
-server.start();
-
-global.Config = require('../lib/config').load(Path.resolve(__dirname, './data/config.json'));
-
-global.Log = require('../lib/logger').attach(global.Config);
-global.Log.remove(winston.transports.Console);
 
 const Metadata = require('../lib/source/metadata');
 const fakeMetadata = JSON.parse(fs.readFileSync(Path.resolve(__dirname, './data/test-metadata.json')));
@@ -123,7 +113,7 @@ describe('Metadata source plugin', () => {
   });
 
   it('exposes an error when one occurs but continues running', (done) => {
-    server.stop();
+    this.m.service.host = '0.0.0.0';
     this.m.on('error', (err) => {
       const status = this.m.status();
 
@@ -141,6 +131,6 @@ describe('Metadata source plugin', () => {
   });
 
   after(() => {
-    server.start();
+    this.m.service.host = '127.0.0.1:8080';
   });
 });

--- a/test/s3.js
+++ b/test/s3.js
@@ -2,36 +2,17 @@
 /* global Config */
 'use strict';
 
-const Path = require('path');
-const winston = require('winston');
 const should = require('should');
 const sinon = require('sinon');
-const proxyquire = require('proxyquire');
 
 require('should-sinon');
 
-global.Config = require('../lib/config').load(Path.resolve(__dirname, './data/config.json'));
-
-global.Log = require('../lib/logger').attach(global.Config);
-global.Log.remove(winston.transports.Console);
-
 const NON_DEFAULT_INTERVAL = 10000;
 const DEFAULT_BUCKET = 'fake-bucket';
-
-function generateProxy(stub) {
-  return proxyquire('../lib/source/s3', {
-    'aws-sdk': {
-      S3: function constructor() {
-        return {getObject: stub
-        };
-      }
-    }
-  });
-}
+const s3Stub = require('./utils/s3-stub');
 
 describe('S3 source plugin', () => {
   let S3,
-      getObjectStub,
       s3WithNoSuchKeyError,
       s3WithNotModifiedError,
       s3OtherError,
@@ -44,11 +25,16 @@ describe('S3 source plugin', () => {
       Body: new Buffer(JSON.stringify({a: 1, b: 'foo', c: {d: 0}}))
     };
 
-    getObjectStub = sinon.stub().callsArgWith(1, null, fakeResponse);
-    S3 = generateProxy(getObjectStub);
+    S3 = s3Stub({
+      getObject: sinon.stub().callsArgWith(1, null, fakeResponse)
+    });
 
     this.s3 = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
     done();
+  });
+
+  afterEach(() => {
+    this.s3.shutdown();
   });
 
   it('throws an error if instantiated without bucket or path', () => {
@@ -71,9 +57,7 @@ describe('S3 source plugin', () => {
 
   it('initializes a timer with the set interval', (done) => {
     this.s3.on('update', () => {
-      const status = this.s3.status();
-
-      status.interval.should.have.keys(['_called', '_idleNext', '_idlePrev', '_idleStart', '_idleTimeout',
+      this.s3._timer.should.have.keys(['_called', '_idleNext', '_idlePrev', '_idleStart', '_idleTimeout',
         '_onTimeout', '_repeat']);
       done();
     });
@@ -103,8 +87,9 @@ describe('S3 source plugin', () => {
   });
 
   before(() => {
-    getObjectStub = sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null);
-    S3 = generateProxy(getObjectStub);
+    S3 = s3Stub({
+      getObject: sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null)
+    });
 
     s3WithNoSuchKeyError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
   });
@@ -127,8 +112,9 @@ describe('S3 source plugin', () => {
   });
 
   before(() => {
-    getObjectStub = sinon.stub().callsArgWith(1, {code: 'NotModified'}, null);
-    S3 = generateProxy(getObjectStub);
+    S3 = s3Stub({
+      getObject: sinon.stub().callsArgWith(1, {code: 'NotModified'}, null)
+    });
 
     s3WithNotModifiedError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
   });
@@ -153,8 +139,9 @@ describe('S3 source plugin', () => {
   before(() => {
     const errorObj = {code: 'BigTimeErrorCode', message: 'This is the error message'};
 
-    getObjectStub = sinon.stub().callsArgWith(1, errorObj, null);
-    S3 = generateProxy(getObjectStub);
+    S3 = s3Stub({
+      getObject: sinon.stub().callsArgWith(1, errorObj, null)
+    });
 
     s3OtherError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
   });
@@ -169,6 +156,7 @@ describe('S3 source plugin', () => {
     });
 
     s3OtherError.initialize();
+    s3OtherError.shutdown();
   });
 
   it('can\'t shutdown a plugin that\'s already shut down', (done) => {
@@ -187,6 +175,7 @@ describe('S3 source plugin', () => {
   it('can only be initialized once', () => {
     this.s3.initialize();
     this.s3.should.deepEqual(this.s3.initialize());
+    this.s3.shutdown();
   });
 
   it('identifies as a \'s3\' source plugin', () => {

--- a/test/utils/s3-stub.js
+++ b/test/utils/s3-stub.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+
+module.exports = function generateS3Proxy(stubs) {
+  return proxyquire('../../lib/source/s3', {
+    'aws-sdk': {
+      S3: function constructor() {
+        return stubs;
+      }
+    }
+  });
+};

--- a/test/utils/test-metadata-server.js
+++ b/test/utils/test-metadata-server.js
@@ -54,7 +54,7 @@ const sockets = {};
 let nextSocketId = 0;
 
 server.on('listening', () => {
-  console.log(`listening for metadata requests at http://127.0.0.1:${DEFAULT_HTTP_PORT}`); // eslint-disable-line
+  console.log(`listening for metadata requests at http://127.0.0.1:${DEFAULT_HTTP_PORT}\n`); // eslint-disable-line
   // no-console
 });
 
@@ -77,4 +77,5 @@ exports.stop = () => {
     }
     console.log('Server shutting down\n'); // eslint-disable-line no-console
   }
+  console.log('Server shutting down\n'); // eslint-disable-line no-console
 };


### PR DESCRIPTION
Added an `init` test file with root `before()` and `after()` hooks. This allows us to have a single test metadata server so we don't get transient `EADDRINUSE` errors.

Also added method to stub out `S3.getObject`. This will be deprecated shortly as there are better methods of achieving this by overloading `AWS.S3.prototype.getObject`.