### PR TITLE
S3#status() exposes the timer object rather than the interval

### DIFF
--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -172,7 +172,7 @@ class S3 extends EventEmitter {
     return {
       ok: this._ok,
       updated: this._updated,
-      interval: this._timer,
+      interval: this.interval,
       running: this._running
     };
   }

--- a/test/s3.js
+++ b/test/s3.js
@@ -8,6 +8,7 @@ const sinon = require('sinon');
 require('should-sinon');
 
 const NON_DEFAULT_INTERVAL = 10000;
+const DEFAULT_INTERVAL = 60000;
 const DEFAULT_BUCKET = 'fake-bucket';
 const s3Stub = require('./utils/s3-stub');
 
@@ -29,7 +30,7 @@ describe('S3 source plugin', () => {
       getObject: sinon.stub().callsArgWith(1, null, fakeResponse)
     });
 
-    this.s3 = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
+    this.s3 = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json', interval: DEFAULT_INTERVAL});
     done();
   });
 
@@ -85,6 +86,22 @@ describe('S3 source plugin', () => {
 
     this.s3.initialize();
   });
+
+  it('returns a properly formed status object', sinon.test((done) => {
+    this.s3.on('update', () => {
+      const status = this.s3.status();
+
+      status.should.eql({
+        ok: true,
+        updated: new Date(),
+        interval: DEFAULT_INTERVAL,
+        running: true
+      });
+      done();
+    });
+
+    this.s3.initialize();
+  }));
 
   before(() => {
     S3 = s3Stub({


### PR DESCRIPTION
Changed the S3#status() output to return the interval rather than the timer. There are edge cases where returning the timer and outputting that data can lead to errors related to nested depth. Plus there's nothing we can actually need from the timer.