### PR TITLE
Default S3 parser wasn't extracting properties object in parsed S3 body

### DIFF
--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -19,7 +19,7 @@ class S3Parser {
     } catch (e) {
       // We should have an error condition but tbd
     }
-    this.properties = properties;
+    this.properties = properties.properties;
   }
 }
 


### PR DESCRIPTION
Fixed bug where the default S3 parser was returning the root object parsed from the S3 body instead of the `properties` object within the root object.

We didn't have any test cases built around data that conformed to the schema so this bug was never picked up.

:thumbsup: to @jmanero-r7 for catching this one.