### PR TITLE
Fix a timing issue in Consul plugin tests around update time.

### DIFF
--- a/test/consul.js
+++ b/test/consul.js
@@ -210,6 +210,7 @@ describe('Consul#status', () => {
   });
 
   it('reports last update time', () => {
+    const start = new Date();
     const consul = generateConsulStub();
 
     consul.initialize();
@@ -217,7 +218,7 @@ describe('Consul#status', () => {
     should(consul.status().updated).be.null();
     consul.mock.emitChange('consul', []);
 
-    return Promise.resolve(consul.status().updated).should.eventually.eql(new Date());
+    return Promise.resolve(consul.status().updated.getTime()).should.eventually.be.aboveOrEqual(start.getTime());
   });
 });
 


### PR DESCRIPTION
We saw an issue on Travis CI where the test failed.
https://travis-ci.org/rapid7/propsd/builds/113500672

We now ensure that `Consul.status().updated` is set to a time that's later than when the test starts.