### PR TITLE
Fix PluginManager state machine

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -264,14 +264,17 @@ class PluginManager extends EventEmitter {
         default:
           this._error(new Error(`Source type ${source.type} not implemented`));
       }
-      this.emit('source-instantiated', instance);
 
-      this.storage.register(instance);
-      this._registerSourceEvents(instance);
-      this.emit('source-registered', instance);
+      if (instance) {
+        this.emit('source-instantiated', instance);
 
-      instance.initialize();
-      this.emit('source-initialized', instance);
+        this.storage.register(instance);
+        this._registerSourceEvents(instance);
+        this.emit('source-registered', instance);
+
+        instance.initialize();
+        this.emit('source-initialized', instance);
+      }
     });
 
     this.index.once('update', () => {

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
-const async = require('async');
 const StringTemplate = require('./string-template');
 const Metadata = require('./source/metadata');
 const S3 = require('./source/s3');
@@ -103,7 +102,6 @@ class PluginManager extends EventEmitter {
     this._running = false;
     this._ok = true;
     this.updateDelay = DEFAULT_CALLBACK_DELAY;
-    this._boundInit = this._init.bind(this);
   }
 
   /**
@@ -174,7 +172,6 @@ class PluginManager extends EventEmitter {
           return StringTemplate.coerce(v, this.metadata.properties);
         });
       });
-
     } catch (error) {
       this._error(error);
       this._registrationRetry = setTimeout(() => {
@@ -187,101 +184,6 @@ class PluginManager extends EventEmitter {
     this.emit('sources-generated', sources);
     this._registerSources(sources);
     this.emit('sources-registered', this.storage.sources);
-  }
-
-  /**
-   * Coordinates synchronizing the index and metadata sources and then mapping them together
-   * @private
-   */
-  _init() {
-    const boundIndex = this._index.bind(this);
-    const boundMapper = this._mapper.bind(this);
-
-    async.series([boundIndex, boundMapper], (err, response) => {
-      // There's no possible error condition because both this._mapper() and this._index() handle
-      // their own errors in order to retry their respective operations.
-      this._ok = true;
-
-      const sources = response[1];
-
-      this.emit('sources-generated', sources);
-      this._registerSources(sources);
-      this.emit('sources-registered', this.storage.sources);
-    });
-  }
-
-  /**
-   * Coordinate fetching the PluginManager's index and metadata source
-   * @param {Function} callback
-   * @returns {null}
-   * @private
-   */
-  _index(callback) {
-    return async.parallel([
-      this._createParallelTask(this.index),
-      this._createParallelTask(this.metadata)
-    ], (err, errSources) => {
-      if (err) {
-        // If any of the parallel tasks fail it means either the Metadata plugin or the index plugin has failed
-        // so we need to determine which plugin threw the error then set a listener on it for its next update to
-        // try to assemble the whole thing again.
-        this._error(err);
-
-        errSources.filter(Boolean).forEach((el) => {
-          el.shutdown();
-          el.once('update', this._boundInit);
-          el.initialize();
-        });
-        return;
-      }
-      callback(null);
-    });
-  }
-
-  /**
-   * Maps instance metadata into the index document
-   * @param {Function} callback
-   * @private
-   */
-  _mapper(callback) {
-    let sources = [];
-
-    try {
-      sources = this.index.properties.map((el) => {
-        return iter(el, (k, v) => {
-          // TODO: No handling for arrays. Are we expecting arrays anywhere in the index?
-          return StringTemplate.coerce(v, this.metadata.properties);
-        });
-      });
-      callback(null, sources);
-    } catch (mappingErr) {
-      this._error(mappingErr);
-      setTimeout(this._boundInit, this.updateDelay);
-    }
-  }
-
-  /**
-   * Create function that feeds async.parallel (or any async marshalling function)
-   * @param {Metadata|S3} source
-   * @returns {Function}
-   * @private
-   */
-  _createParallelTask(source) {
-    return (c) => {
-      const callBackErr = (err) => {
-        source.removeListener('update', callBackSuccess); // eslint-disable-line no-use-before-define
-        c(err, source);
-      };
-      const callBackSuccess = () => {
-        source.removeListener('error', callBackErr);
-        c(null);
-      };
-
-      source.shutdown();
-      source.once('update', callBackSuccess);
-      source.once('error', callBackErr);
-      source.initialize();
-    };
   }
 
   /**

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -276,13 +276,6 @@ class PluginManager extends EventEmitter {
         this.emit('source-initialized', instance);
       }
     });
-
-    this.index.once('update', () => {
-      setTimeout(() => {
-        Log.info('There was an update to the index document.');
-        this._boundInit();
-      }, this.updateDelay);
-    });
   }
 
   /**

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -298,9 +298,7 @@ class PluginManager extends EventEmitter {
 
     source.on('update', () => {
       Log.info(`${source.name}'s data was updated from its underlying source data.`);
-      setInterval(() => {
-        this.storage.update();
-      }, this.updateDelay);
+      this.storage.update();
     });
 
     source.on('no-update', () => {

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -157,6 +157,10 @@ class PluginManager extends EventEmitter {
   }
 
   /**
+   * Called when either the S3 index or EC2 metadata are updated. If parsing of
+   * of composite properties fails, an error is logged. Once parsing succeeds,
+   * any additional sources in the index are registered.
+   * @private
    */
   _loadSourcesFromIndex() {
     let sources = [];

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -77,14 +77,29 @@ class PluginManager extends EventEmitter {
     const configuration = options || Object.create(null);
 
     this.storage = storage;
+
     this.index = new S3({
       interval: configuration.interval || DEFAULT_INDEX_INTERVAL,
       bucket: configuration.bucket || DEFAULT_INDEX_BUCKET,
       path: configuration.path || DEFAULT_INDEX_PATH,
       parser: new S3IndexParser()
     });
+    this.index.on('error', (error) => {
+      this._error(error);
+    });
+    this.index.on('update', () => {
+      this._loadSourcesFromIndex();
+    });
+
     this.metadata = new Metadata();
     this.metadata.service.host = configuration.metadataHost || Config.get('metadata:host');
+    this.metadata.on('error', (error) => {
+      this._error(error);
+    });
+    this.metadata.on('update', () => {
+      this._loadSourcesFromIndex();
+    });
+
     this._running = false;
     this._ok = true;
     this.updateDelay = DEFAULT_CALLBACK_DELAY;
@@ -96,8 +111,9 @@ class PluginManager extends EventEmitter {
    */
   initialize() {
     Log.info('Initializing index and metadata');
+    this.index.initialize();
+    this.metadata.initialize();
     this._running = true;
-    this._init();
   }
 
   /**
@@ -142,6 +158,35 @@ class PluginManager extends EventEmitter {
         status: source.status()
       };
     });
+  }
+
+  /**
+   */
+  _loadSourcesFromIndex() {
+    let sources = [];
+
+    clearTimeout(this._registrationRetry);
+
+    try {
+      sources = this.index.properties.map((el) => {
+        return iter(el, (k, v) => {
+          // TODO: No handling for arrays. Are we expecting arrays anywhere in the index?
+          return StringTemplate.coerce(v, this.metadata.properties);
+        });
+      });
+
+    } catch (error) {
+      this._error(error);
+      this._registrationRetry = setTimeout(() => {
+        this._loadSourcesFromIndex();
+      }, this.updateDelay);
+      return;
+    }
+
+    this._ok = true;
+    this.emit('sources-generated', sources);
+    this._registerSources(sources);
+    this.emit('sources-registered', this.storage.sources);
   }
 
   /**

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -13,7 +13,6 @@ const S3 = require('./source/s3');
 const DEFAULT_INDEX_INTERVAL = Config.get('index:interval') || 60000; // eslint-disable-line rapid7/static-magic-numbers
 const DEFAULT_INDEX_BUCKET = Config.get('index:bucket');
 const DEFAULT_INDEX_PATH = Config.get('index:path');
-const DEFAULT_CALLBACK_DELAY = 2000;
 
 /**
  * Recursively iterate through an object applying the callback to each k/v pair
@@ -101,7 +100,6 @@ class PluginManager extends EventEmitter {
 
     this._running = false;
     this._ok = true;
-    this.updateDelay = DEFAULT_CALLBACK_DELAY;
   }
 
   /**
@@ -163,8 +161,6 @@ class PluginManager extends EventEmitter {
   _loadSourcesFromIndex() {
     let sources = [];
 
-    clearTimeout(this._registrationRetry);
-
     try {
       sources = this.index.properties.map((el) => {
         return iter(el, (k, v) => {
@@ -174,9 +170,6 @@ class PluginManager extends EventEmitter {
       });
     } catch (error) {
       this._error(error);
-      this._registrationRetry = setTimeout(() => {
-        this._loadSourcesFromIndex();
-      }, this.updateDelay);
       return;
     }
 

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -114,17 +114,10 @@ class PluginManager extends EventEmitter {
 
   /**
    * Shutdown the plugin manager's sources and then the plugin manager
-   * @param {Boolean} del
    */
-  shutdown(del) {
+  shutdown() {
     Log.info('Shutting down sources');
-    this.storage.sources.forEach((source) => {
-      source.shutdown();
-    });
-
-    if (del === true) {
-      this.storage.sources = [];
-    }
+    this.storage.clear();
 
     this._running = false;
   }
@@ -189,6 +182,9 @@ class PluginManager extends EventEmitter {
    * @private
    */
   _registerSources(sources) {
+    // TODO: WRITE TESTS
+    this.storage.clear();
+
     sources.forEach((source) => {
       let instance;
 

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -109,9 +109,9 @@ class PluginManager extends EventEmitter {
    */
   initialize() {
     Log.info('Initializing index and metadata');
+    this._running = true;
     this.index.initialize();
     this.metadata.initialize();
-    this._running = true;
   }
 
   /**

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -76,6 +76,7 @@ class Storage {
    * Remove all source plugins from storage
    */
   clear() {
+    // TODO: WRITE TESTS
     let i = this.sources.length;
 
     while (i--) {
@@ -88,6 +89,10 @@ class Storage {
    * @param {Object} plugin
    */
   unregister(plugin) {
+    // TODO: WRITE TESTS
+    if (typeof plugin.shutdown === typeof (Function)) {
+      plugin.shutdown();
+    }
     const index = this.sources.indexOf(plugin);
 
     if (index !== -1) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -82,6 +82,7 @@ class Storage {
     while (i--) {
       this.unregister(this.sources[i]);
     }
+    this.properties = Object.create(null);
   }
 
   /**
@@ -90,7 +91,7 @@ class Storage {
    */
   unregister(plugin) {
     // TODO: WRITE TESTS
-    if (typeof plugin.shutdown === typeof (Function)) {
+    if (plugin.shutdown instanceof Function) {
       plugin.shutdown();
     }
     const index = this.sources.indexOf(plugin);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "walk": "^2.3.9"
   },
   "dependencies": {
-    "async": "^1.5.2",
     "aws-sdk": "^2.2.28",
     "consul": "^0.23.0",
     "express": "^4.13.3",

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -78,7 +78,7 @@ describe('Plugin manager', function () {
       Body: new Buffer(JSON.stringify(badIndex))
     });
 
-    manager.on('error', () => {
+    manager.once('error', () => {
       AWS.S3.prototype.getObject = sinon.stub().callsArgWith(1, null, fakeIndexResponse);
       manager.once('sources-generated', (sources) => {
         const sourceObjs = sources.map((s) => {

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -91,7 +91,6 @@ describe('Plugin manager', function () {
       done();
     });
 
-    manager.updateDelay = 1;
     manager.index.interval = 1;
     manager.initialize();
   });
@@ -166,7 +165,6 @@ describe('Plugin manager', function () {
     });
 
     manager.metadata.service.host = '0.0.0.0';
-    manager.updateDelay = 1;
     manager.metadata.interval = 1;
     manager.initialize();
   });
@@ -195,7 +193,6 @@ describe('Plugin manager', function () {
       done();
     });
 
-    manager.updateDelay = 1;
     manager.index.interval = 1;
     manager.initialize();
   });

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -80,16 +80,19 @@ describe('Plugin manager', function () {
 
     manager.once('error', () => {
       AWS.S3.prototype.getObject = sinon.stub().callsArgWith(1, null, fakeIndexResponse);
-      manager.once('sources-generated', (sources) => {
-        const sourceObjs = sources.map((s) => {
-          return {name: s.name, type: s.type};
-        });
-
-        sourceObjs.should.eql([{name: 'global', type: 's3'}, {name: 'account', type: 's3'}, {name: 'ami', type: 's3'}]);
-        done();
-      });
     });
+
+    manager.once('sources-generated', (sources) => {
+      const sourceObjs = sources.map((s) => {
+        return {name: s.name, type: s.type};
+      });
+
+      sourceObjs.should.eql([{name: 'global', type: 's3'}, {name: 'account', type: 's3'}, {name: 'ami', type: 's3'}]);
+      done();
+    });
+
     manager.updateDelay = 1;
+    manager.index.interval = 1;
     manager.initialize();
   });
 

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -144,15 +144,17 @@ describe('Plugin manager', function () {
   });
 
   it('retries Metadata source until it succeeds if the Metadata source fails', function (done) {
-    manager.once('error', (err) => {
-      const metadataStatus = manager.metadata.status();
+    manager.on('error', (err) => {
+      if (err.code === 'ECONNREFUSED') {
+        const metadataStatus = manager.metadata.status();
 
-      err.code.should.equal('ECONNREFUSED');
-      manager.status().should.eql({running: true, ok: false, sources: []});
-      metadataStatus.ok.should.be.false();
-      metadataStatus.running.should.be.true();
+        err.code.should.equal('ECONNREFUSED');
+        manager.status().should.eql({running: true, ok: false, sources: []});
+        metadataStatus.ok.should.be.false();
+        metadataStatus.running.should.be.true();
 
-      manager.metadata.service.host = '127.0.0.1:8080';
+        manager.metadata.service.host = '127.0.0.1:8080';
+      }
     });
 
     manager.once('sources-generated', (sources) => {
@@ -165,6 +167,8 @@ describe('Plugin manager', function () {
     });
 
     manager.metadata.service.host = '0.0.0.0';
+    manager.updateDelay = 1;
+    manager.metadata.interval = 1;
     manager.initialize();
   });
 


### PR DESCRIPTION
This replaces the bootstrap logic in PluginManager by listening for updates and retrying on a timer. The end result is slightly slower boot time in the worst case. If data from the EC2 metadata or S3 index are unavailable, the PluginManager waits until it gets an update form one or the other before parsing the index for additional sources.