### PR TITLE
Fix tests spamming "Server shutting down"

### DIFF
--- a/test/utils/test-metadata-server.js
+++ b/test/utils/test-metadata-server.js
@@ -77,5 +77,4 @@ exports.stop = () => {
     }
     console.log('Server shutting down\n'); // eslint-disable-line no-console
   }
-  console.log('Server shutting down\n'); // eslint-disable-line no-console
 };


### PR DESCRIPTION
An extra console.log statement snuck in during a merge somewhere. This is what caused tests to spam 'Server shutting down'.