### PR TITLE
Fix tests spamming "Server shutting down" for real

### DIFF
--- a/test/utils/test-metadata-server.js
+++ b/test/utils/test-metadata-server.js
@@ -75,6 +75,6 @@ exports.stop = () => {
     if (sockets.hasOwnProperty(socketId)) {
       sockets[socketId].destroy();
     }
-    console.log('Server shutting down\n'); // eslint-disable-line no-console
   }
+  console.log('Server shutting down\n'); // eslint-disable-line no-console
 };


### PR DESCRIPTION
#57 accidentally deleted the extra log statement that was outside the loop. This removes the one inside the loop. So now there's only one "Server shutting down" statement.