### PR TITLE
Config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,53 @@ so you can run propsd without terminal output. Log files aren't rotated by
 propsd, so you'll want to configure something externally to handle that if
 you enable file logging.
 
+### properties
+
+The `properties` object can contain any arbitrary properties you want loaded into the `Metadata#properties` object when it's being used to interpolate sources from the index. 
+
+For example, a config file with the following `properties` object:
+
+~~~json
+{
+	...
+	"properties": {
+		"foo": "bar",
+		"baz": "s3"
+	}
+	...
+}	
+~~~
+
+When presented with the following index document:
+
+~~~json
+{
+	"version": 1.0,
+	"sources": [
+		{
+			"name": "foo",
+			"type": "{{ baz }}",
+			"parameters": {
+				"path": "{{ foo }}.json"
+			}
+		}
+	]
+}
+~~~
+
+Will yield this source:
+
+~~~json
+{
+	"name": "foo",
+	"type": "s3",
+	"parameters": {
+		"path": "bar.json"
+	}
+}
+~~~
+
+
 ### Example
 
 An example configuration file is shown below. The server's address is set to

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -158,6 +158,13 @@ class PluginManager extends EventEmitter {
   _loadSourcesFromIndex() {
     let sources = [];
 
+    if (Object.keys(this.metadata.properties).length > 0) {
+      const configProps = Config.get('properties');
+
+      if (typeof configProps !== 'undefined') {
+        this.metadata.properties = Object.assign(configProps, this.metadata.properties);
+      }
+    }
     try {
       sources = this.index.properties.map((el) => {
         return iter(el, (k, v) => {

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -161,7 +161,7 @@ class PluginManager extends EventEmitter {
     if (Object.keys(this.metadata.properties).length > 0) {
       const configProps = Config.get('properties');
 
-      if (typeof configProps !== 'undefined') {
+      if (configProps) {
         this.metadata.properties = Object.assign(configProps, this.metadata.properties);
       }
     }


### PR DESCRIPTION
Merge properties delivered via the Config object with the metadata properties.

We'll eventually phase this out in favor of using a `File` source, but it's a good stop-gap until that's fully implemented and being polled in the `PluginManager`.