### PR TITLE
Adding coveralls.io support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ sudo: false
 script:
   - npm run lint
   - npm run test
+after_success:
+  npm run report-coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Propsd
-
+[![Build Status][travis-image]][travis-url] [![Coverage Status][coveralls-image]][coveralls-url]
 ## Usage
 
 The Propsd server runs under [Node.js][]. Run the following command to start it.
@@ -45,7 +45,7 @@ you enable file logging.
 
 ### properties
 
-The `properties` object can contain any arbitrary properties you want loaded into the `Metadata#properties` object when it's being used to interpolate sources from the index. 
+The `properties` object can contain any arbitrary properties you want loaded into the `Metadata#properties` object when it's being used to interpolate sources from the index.
 
 For example, a config file with the following `properties` object:
 
@@ -162,3 +162,7 @@ If an `endpoint` key is provided, the S3 source and it's underlying client will 
 
 [Node.js]: https://nodejs.org/en/
 [http-api]: docs/http-api.md
+[travis-image]: https://travis-ci.org/rapid7/propsd.svg?branch=master
+[travis-url]: https://travis-ci.org/rapid7/propsd
+[coveralls-image]: https://coveralls.io/repos/rapid7/propsd/badge.svg?branch=master&service=github
+[coveralls-url]: https://coveralls.io/github/rapid7/propsd?branch=master

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "mocha",
     "lint": "eslint bin/** lib/** test/**",
     "coverage": "istanbul cover _mocha -- -R spec",
+    "report-coverage": "npm run coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "metadata-server": "./test/bin/metadata-server.js",
     "s3-server": "./test/bin/s3-server.js"
   },
@@ -27,6 +28,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
+    "coveralls": "^2.11.8",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^3.1.0",
     "eslint-config-rapid7": "0.0.15",
@@ -34,6 +36,7 @@
     "eslint-plugin-react": "^3.14.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
+    "mocha-lcov-reporter": "^1.2.0",
     "proxyquire": "^1.7.4",
     "rimraf": "^2.5.2",
     "s3rver": "0.0.13",


### PR DESCRIPTION
Added coveralls and mocha clove reporter. Added report-coverage npm task that runs coverage reports and sends it to coveralls.io. Added that task to Travis if linting and tests succeed.