### PR TITLE
Fix: Namespaced Consul properties

### DIFF
--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -21,6 +21,7 @@ class Consul extends EventEmitter {
     this.type = 'consul';
     this.name = 'consul';
     this.properties = Object.create(null);
+    this.properties.consul = Object.create(null);
     this._okay = false;
     this._updated = null;
   }
@@ -103,6 +104,7 @@ class Consul extends EventEmitter {
    */
   clear() {
     this.properties = Object.create(null);
+    this.properties.consul = Object.create(null);
   }
 
   /**
@@ -209,14 +211,14 @@ class Consul extends EventEmitter {
         }
       });
 
-      if (!this.properties[name]) {
-        this.properties[name] = Object.create(null);
+      if (!this.properties.consul[name]) {
+        this.properties.consul[name] = Object.create(null);
       }
-      this.properties[name].addresses = addresses.sort();
+      this.properties.consul[name].addresses = addresses.sort();
     } else {
       // Empty data means the service has been deregistered.
       this._unregisterHealthWatcher(name);
-      delete this.properties[name];
+      delete this.properties.consul[name];
     }
 
     this._okay = true;

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -17,11 +17,10 @@ class Consul extends EventEmitter {
   constructor(options) {
     super();
     this.configure(options);
+    this.clear();
 
     this.type = 'consul';
     this.name = 'consul';
-    this.properties = Object.create(null);
-    this.properties.consul = Object.create(null);
     this._okay = false;
     this._updated = null;
   }

--- a/test/consul.js
+++ b/test/consul.js
@@ -253,7 +253,7 @@ describe('Consul', () => {
     consul.mock.emitChange('catalog-service', {consul: []});
     consul.mock.emitChange('consul', []);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({});
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({});
   });
 
   it('resolves addresses at the node level by default', () => {
@@ -265,7 +265,7 @@ describe('Consul', () => {
       Node: {Address: '10.0.0.0'}
     }]);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({
       consul: {addresses: ['10.0.0.0']}
     });
   });
@@ -279,7 +279,7 @@ describe('Consul', () => {
       Node: {Address: ''}
     }]);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({
       consul: {addresses: []}
     });
   });
@@ -294,7 +294,7 @@ describe('Consul', () => {
       Service: {Address: '127.0.0.1'}
     }]);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({
       consul: {addresses: ['127.0.0.1']}
     });
   });
@@ -309,7 +309,7 @@ describe('Consul', () => {
       Service: {Address: ''}
     }]);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({
       consul: {addresses: ['10.0.0.0']}
     });
   });
@@ -325,7 +325,7 @@ describe('Consul', () => {
       Node: {Address: '10.0.0.0'}
     }]);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({
       consul: {addresses: ['10.0.0.0', '127.0.0.1']}
     });
   });
@@ -342,7 +342,7 @@ describe('Consul', () => {
       Service: {Address: '10.0.0.0'}
     }]);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({
       'consul-production': {addresses: ['127.0.0.1']},
       'consul-development': {addresses: ['10.0.0.0']}
     });
@@ -363,7 +363,7 @@ describe('Consul', () => {
       Service: {Address: '10.0.0.0'}
     }]);
 
-    return Promise.resolve(consul.properties).should.eventually.eql({
+    return Promise.resolve(consul.properties.consul).should.eventually.eql({
       'consul-production': {addresses: ['127.0.0.1']},
       'elasticsearch-production': {addresses: ['10.0.0.0']}
     });
@@ -449,7 +449,7 @@ describe('Consul', () => {
 
     consul.on('update', () => {
       consul.clear();
-      should(consul.properties).eql({});
+      should(consul.properties.consul).eql({});
       done();
     });
 

--- a/test/consul.js
+++ b/test/consul.js
@@ -236,6 +236,16 @@ describe('Consul', () => {
     consul.mock.emitError('consul', new Error('Mock health/service error'));
   });
 
+  it('namespaces resolved properties within a "consul" group', () => {
+    const consul = generateConsulStub();
+
+    consul.initialize();
+    consul.mock.emitChange('catalog-service', {consul: []});
+    consul.mock.emitChange('consul', []);
+
+    return Promise.resolve(consul.properties).should.eventually.have.property('consul');
+  });
+
   it('resolves an empty object if no addresses are found', () => {
     const consul = generateConsulStub();
 


### PR DESCRIPTION
As part of #61, the Conqueso API needs to be able to recognize that properties it's formatting are from Consul. This fixes the Consul plugin so it namespaces its generated properties by enclosing them in a "consul" object.

I've kind of viewing this as a temporary fix for now. Long term, we may want to come up with a design around an internal "properties" structure. That would allow us to define rendering rules based on property metadata.