### PR TITLE
Fix: Better Conqueso compatibility

### DIFF
--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -6,7 +6,7 @@ const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
 
 /**
- * Format the given data as Java properites
+ * Format the given data as Java properties
  *
  * @param {Object} data
  * @return {String}

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -36,25 +36,19 @@ function makeJavaProperties(data) {
  *   "conqueso.service.ips": "x.x.x.x, y.y.y.y"
  * }
  *
- * @param {Object} properties  Flattened properties as returned from Storage#properties
- * @return {Object}             Properties with Consul address converted to Conqueso ones
+ * @param {Object} properties  Properties as returned from Storage#properties
+ * @return {Object}            Properties with Consul address converted to Conqueso ones
  */
 function transformAddresses(properties) {
-  const results = {};
+  const conquesoIps = Object.create(null);
 
-  for (const key in properties) {
-    if (properties.hasOwnProperty(key)) {
-      if (key.startsWith('consul') && key.endsWith('addresses')) {
-        const service = key.split('.')[1];
-
-        results[`conqueso.${service}.ips`] = properties[key].join(',');
-      } else {
-        results[key] = properties[key];
-      }
-    }
+  if (properties.consul) {
+    Object.keys(properties.consul).forEach((service) => {
+      conquesoIps[`conqueso.${service}.ips`] = properties.consul[service].addresses.join(',');
+    });
   }
 
-  return results;
+  return Object.assign(properties, conquesoIps);
 }
 
 /**
@@ -64,11 +58,9 @@ function transformAddresses(properties) {
  * @return {String}            Flattened Java properties as returned by Conqueso
  */
 function makeConquesoProperties(properties) {
-  let results = flatten(properties, {
-    safe: true
-  });
+  let results = transformAddresses(properties);
 
-  results = transformAddresses(results);
+  results = flatten(results);
 
   return makeJavaProperties(results);
 }

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -24,15 +24,53 @@ function makeJavaProperties(data) {
 }
 
 /**
+ * Converts Consul addresess to Conqueso addresses
+ *
+ * Addresses returned by the Consul plugin are formatted as
+ * {
+ *   "consul.service.addresses": ["x.x.x.x", "y.y.y.y"]
+ * }
+ *
+ * Addresses returned by Conqueso are formatted as
+ * {
+ *   "conqueso.service.ips": "x.x.x.x, y.y.y.y"
+ * }
+ *
+ * @param {Object} properties  Flattened properties as returned from Storage#properties
+ * @return {Object}             Properties with Consul address converted to Conqueso ones
+ */
+function transformAddresses(properties) {
+  const results = {};
+
+  for (const key in properties) {
+    if (properties.hasOwnProperty(key)) {
+      if (key.startsWith('consul') && key.endsWith('addresses')) {
+        const service = key.split('.')[1];
+
+        results[`conqueso.${service}.ips`] = properties[key].join(',');
+      } else {
+        results[key] = properties[key];
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
  * Format the given properties as Conqueso properties
  *
  * @param {Object} properties  Properties as returned from Storage#properties
  * @return {String}            Flattened Java properties as returned by Conqueso
  */
 function makeConquesoProperties(properties) {
-  const flatProperties = flatten(properties);
+  let results = flatten(properties, {
+    safe: true
+  });
 
-  return makeJavaProperties(flatProperties);
+  results = transformAddresses(results);
+
+  return makeJavaProperties(results);
 }
 
 /**

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -39,7 +39,7 @@ function makeJavaProperties(data) {
  * @param {Object} properties  Properties as returned from Storage#properties
  * @return {Object}            Properties with Consul address converted to Conqueso ones
  */
-function transformAddresses(properties) {
+function injectConquesoAddresses(properties) {
   const conquesoIps = Object.create(null);
 
   if (properties.consul) {
@@ -58,7 +58,7 @@ function transformAddresses(properties) {
  * @return {String}            Flattened Java properties as returned by Conqueso
  */
 function makeConquesoProperties(properties) {
-  let results = transformAddresses(properties);
+  let results = injectConquesoAddresses(properties);
 
   results = flatten(results);
 

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -6,6 +6,36 @@ const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
 
 /**
+ * Format the given data as Java properites
+ *
+ * @param {Object} data
+ * @return {String}
+ */
+function makeJavaProperties(data) {
+  const results = [];
+
+  for (const key in data) {
+    if (data.hasOwnProperty(key)) {
+      results.push(key + '=' + data[key]);
+    }
+  }
+
+  return results.join('\n');
+}
+
+/**
+ * Format the given properties as Conqueso properties
+ *
+ * @param {Object} properties  Properties as returned from Storage#properties
+ * @return {String}            Flattened Java properties as returned by Conqueso
+ */
+function makeConquesoProperties(properties) {
+  const flatProperties = flatten(properties);
+
+  return makeJavaProperties(flatProperties);
+}
+
+/**
  * Conqueso compatible API
  *
  * @param {Express.App} app
@@ -21,28 +51,10 @@ function Conqueso(app, storage) {
     res.end();
   }
 
-  /**
-   * Format the given data as Java properites
-   *
-   * @param {Object} data
-   * @return {String}
-   */
-  function makeJavaProperties(data) {
-    const results = [];
-
-    for (const key in data) {
-      if (data.hasOwnProperty(key)) {
-        results.push(key + '=' + data[key]);
-      }
-    }
-
-    return results.join('\n');
-  }
-
   route.get((req, res) => {
     res.set('Content-Type', 'text/plain');
     res.status(HTTP_OK);
-    res.end(makeJavaProperties(flatten(storage.properties)));
+    res.end(makeConquesoProperties(storage.properties));
   });
 
   // Express defaults to using the GET route for HEAD requests.

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -136,7 +136,7 @@ describe('Conqueso API v1', () => {
   });
 });
 
-describe('Conqueso API vi1', () => {
+describe('Conqueso API v1', () => {
   let consul = null,
       server = null;
 
@@ -164,6 +164,25 @@ describe('Conqueso API vi1', () => {
       elasticsearch: []
     });
     consul.mock.emitChange('elasticsearch', [{
+      Service: {Address: '10.0.0.0'}
+    }, {
+      Service: {Address: '127.0.0.1'}
+    }]);
+  });
+
+  it('formats IP addresses for tagged Consul services', (done) => {
+    consul.on('update', () => {
+      request(server)
+        .get('/v1/conqueso/api/roles')
+        .set('Accept', 'text/plain')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(HTTP_OK, 'conqueso.es-production.ips=10.0.0.0,127.0.0.1', done);
+    });
+
+    consul.mock.emitChange('catalog-service', {
+      elasticsearch: ['es-production']
+    });
+    consul.mock.emitChange('es-production', [{
       Service: {Address: '10.0.0.0'}
     }, {
       Service: {Address: '127.0.0.1'}

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -152,12 +152,18 @@ describe('Conqueso API v1', () => {
   });
 
   it('formats IP addresses for untagged Consul services', (done) => {
+    const expectedBody = [
+      'consul.elasticsearch.addresses.0=10.0.0.0',
+      'consul.elasticsearch.addresses.1=127.0.0.1',
+      'conqueso.elasticsearch.ips=10.0.0.0,127.0.0.1'
+    ].join('\n');
+
     consul.on('update', () => {
       request(server)
         .get('/v1/conqueso/api/roles')
         .set('Accept', 'text/plain')
         .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(HTTP_OK, 'conqueso.elasticsearch.ips=10.0.0.0,127.0.0.1', done);
+        .expect(HTTP_OK, expectedBody, done);
     });
 
     consul.mock.emitChange('catalog-service', {

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -137,15 +137,14 @@ describe('Conqueso API v1', () => {
 });
 
 describe('Conqueso API vi1', () => {
-  let consul = null;
-  let server = null;
+  let consul = null,
+      server = null;
 
   before(() => {
     consul = generateConsulStub();
     server = makeServer(consul);
     consul.initialize();
   });
-
 
   after((done) => {
     consul.shutdown();
@@ -166,7 +165,7 @@ describe('Conqueso API vi1', () => {
     });
     consul.mock.emitChange('elasticsearch', [{
       Service: {Address: '10.0.0.0'}
-    },{
+    }, {
       Service: {Address: '127.0.0.1'}
     }]);
   });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -157,7 +157,7 @@ describe('Conqueso API vi1', () => {
         .get('/v1/conqueso/api/roles')
         .set('Accept', 'text/plain')
         .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(HTTP_OK, 'elasticsearch.addresses=10.0.0.0,127.0.0.1', done);
+        .expect(HTTP_OK, 'conqueso.elasticsearch.ips=10.0.0.0,127.0.0.1', done);
     });
 
     consul.mock.emitChange('catalog-service', {

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -170,22 +170,12 @@ describe('Conqueso API v1', () => {
     }]);
   });
 
-  it('formats IP addresses for tagged Consul services', (done) => {
-    consul.on('update', () => {
-      request(server)
-        .get('/v1/conqueso/api/roles')
-        .set('Accept', 'text/plain')
-        .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(HTTP_OK, 'conqueso.es-production.ips=10.0.0.0,127.0.0.1', done);
-    });
-
-    consul.mock.emitChange('catalog-service', {
-      elasticsearch: ['es-production']
-    });
-    consul.mock.emitChange('es-production', [{
-      Service: {Address: '10.0.0.0'}
-    }, {
-      Service: {Address: '127.0.0.1'}
-    }]);
-  });
+  /**
+   * The goal is that IP addresses for tagged services are named by their tag.
+   * So "consul.service-tag.addresses" becomes "conqueso.tag.ips". This may
+   * require some refactoring in the Consul plugin and tests so they don't use
+   * hyphens as delimiters (or just ensure that Consul tags aren't parsed with
+   * hyphens in their name).
+   */
+  it('formats IP addresses for tagged Consul services');
 });


### PR DESCRIPTION
Another piece of puzzle around #61 to get the Conqueso API formatting output correctly. This translates from IP addresses as they're returned in the Consul plugin into the format defined by Conqueso. Currently on non-tagged services are supported. Tagged services will be handled in a separate pull request. There's a pending test to make sure I don't forget to do that work.