### PR TITLE
Fix: Handle tagged Conqueso IPs

### DIFF
--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -44,7 +44,9 @@ function injectConquesoAddresses(properties) {
 
   if (properties.consul) {
     Object.keys(properties.consul).forEach((service) => {
-      conquesoIps[`conqueso.${service}.ips`] = properties.consul[service].addresses.join(',');
+      const cluster = properties.consul[service].cluster;
+
+      conquesoIps[`conqueso.${cluster}.ips`] = properties.consul[service].addresses.join(',');
     });
   }
 

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -137,6 +137,7 @@ class Consul extends EventEmitter {
       tags.forEach((tag) => {
         watcherInfo.push({
           name: `${service}-${tag}`,
+          cluster: tag,
           options: {
             passing: true,
             service,
@@ -148,6 +149,7 @@ class Consul extends EventEmitter {
       if (tags.length <= 0) {
         watcherInfo.push({
           name: service,
+          cluster: service,
           options: {
             passing: true,
             service
@@ -171,7 +173,7 @@ class Consul extends EventEmitter {
       });
 
       watcher.on('change', (healthServiceData) => {
-        this._onHealthServiceChange(info.name, healthServiceData);
+        this._onHealthServiceChange(info.name, info.cluster, healthServiceData);
       });
 
       this._registerHealthWatcher(info.name, watcher);
@@ -193,11 +195,12 @@ class Consul extends EventEmitter {
    *   }
    * }]
    *
-   * @param {String} name  The name of the watcher
-   * @param {Array} data  The JSON data from the health/service API
+   * @param {String} name     The name of the watcher
+   * @param {String} cluster  The name of the clustered service
+   * @param {Array} data      The JSON data from the health/service API
    * @private
    */
-  _onHealthServiceChange(name, data) {
+  _onHealthServiceChange(name, cluster, data) {
     if (data.length > 0) {
       const addresses = [];
 
@@ -214,6 +217,7 @@ class Consul extends EventEmitter {
         this.properties.consul[name] = Object.create(null);
       }
       this.properties.consul[name].addresses = addresses.sort();
+      this.properties.consul[name].cluster = cluster;
     } else {
       // Empty data means the service has been deregistered.
       this._unregisterHealthWatcher(name);

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -140,13 +140,13 @@ describe('Conqueso API v1', () => {
   let consul = null,
       server = null;
 
-  before(() => {
+  beforeEach(() => {
     consul = generateConsulStub();
     server = makeServer(consul);
     consul.initialize();
   });
 
-  after((done) => {
+  afterEach((done) => {
     consul.shutdown();
     server.close(done);
   });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -176,12 +176,28 @@ describe('Conqueso API v1', () => {
     }]);
   });
 
-  /**
-   * The goal is that IP addresses for tagged services are named by their tag.
-   * So "consul.service-tag.addresses" becomes "conqueso.tag.ips". This may
-   * require some refactoring in the Consul plugin and tests so they don't use
-   * hyphens as delimiters (or just ensure that Consul tags aren't parsed with
-   * hyphens in their name).
-   */
-  it('formats IP addresses for tagged Consul services');
+  it('formats IP addresses for tagged Consul services', (done) => {
+    const expectedBody = [
+      'consul.elasticsearch-sweet-es-cluster.addresses.0=10.0.0.0',
+      'consul.elasticsearch-sweet-es-cluster.addresses.1=127.0.0.1',
+      'conqueso.sweet-es-cluster.ips=10.0.0.0,127.0.0.1'
+    ].join('\n');
+
+    consul.on('update', () => {
+      request(server)
+        .get('/v1/conqueso/api/roles')
+        .set('Accept', 'text/plain')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(HTTP_OK, expectedBody, done);
+    });
+
+    consul.mock.emitChange('catalog-service', {
+      elasticsearch: ['sweet-es-cluster']
+    });
+    consul.mock.emitChange('elasticsearch-sweet-es-cluster', [{
+      Service: {Address: '10.0.0.0'}
+    }, {
+      Service: {Address: '127.0.0.1'}
+    }]);
+  });
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -155,6 +155,7 @@ describe('Conqueso API v1', () => {
     const expectedBody = [
       'consul.elasticsearch.addresses.0=10.0.0.0',
       'consul.elasticsearch.addresses.1=127.0.0.1',
+      'consul.elasticsearch.cluster=elasticsearch',
       'conqueso.elasticsearch.ips=10.0.0.0,127.0.0.1'
     ].join('\n');
 
@@ -180,6 +181,7 @@ describe('Conqueso API v1', () => {
     const expectedBody = [
       'consul.elasticsearch-sweet-es-cluster.addresses.0=10.0.0.0',
       'consul.elasticsearch-sweet-es-cluster.addresses.1=127.0.0.1',
+      'consul.elasticsearch-sweet-es-cluster.cluster=sweet-es-cluster',
       'conqueso.sweet-es-cluster.ips=10.0.0.0,127.0.0.1'
     ].join('\n');
 

--- a/test/consul.js
+++ b/test/consul.js
@@ -266,7 +266,10 @@ describe('Consul', () => {
     }]);
 
     return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      consul: {addresses: ['10.0.0.0']}
+      consul: {
+        cluster: 'consul',
+        addresses: ['10.0.0.0']
+      }
     });
   });
 
@@ -280,7 +283,10 @@ describe('Consul', () => {
     }]);
 
     return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      consul: {addresses: []}
+      consul: {
+        cluster: 'consul',
+        addresses: []
+      }
     });
   });
 
@@ -295,7 +301,10 @@ describe('Consul', () => {
     }]);
 
     return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      consul: {addresses: ['127.0.0.1']}
+      consul: {
+        cluster: 'consul',
+        addresses: ['127.0.0.1']
+      }
     });
   });
 
@@ -310,7 +319,10 @@ describe('Consul', () => {
     }]);
 
     return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      consul: {addresses: ['10.0.0.0']}
+      consul: {
+        cluster: 'consul',
+        addresses: ['10.0.0.0']
+      }
     });
   });
 
@@ -326,7 +338,10 @@ describe('Consul', () => {
     }]);
 
     return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      consul: {addresses: ['10.0.0.0', '127.0.0.1']}
+      consul: {
+        cluster: 'consul',
+        addresses: ['10.0.0.0', '127.0.0.1']
+      }
     });
   });
 
@@ -343,8 +358,14 @@ describe('Consul', () => {
     }]);
 
     return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      'consul-production': {addresses: ['127.0.0.1']},
-      'consul-development': {addresses: ['10.0.0.0']}
+      'consul-production': {
+        cluster: 'production',
+        addresses: ['127.0.0.1']
+      },
+      'consul-development': {
+        cluster: 'development',
+        addresses: ['10.0.0.0']
+      }
     });
   });
 
@@ -364,8 +385,14 @@ describe('Consul', () => {
     }]);
 
     return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      'consul-production': {addresses: ['127.0.0.1']},
-      'elasticsearch-production': {addresses: ['10.0.0.0']}
+      'consul-production': {
+        cluster: 'production',
+        addresses: ['127.0.0.1']
+      },
+      'elasticsearch-production': {
+        cluster: 'production',
+        addresses: ['10.0.0.0']
+      }
     });
   });
 


### PR DESCRIPTION
This fixes #61. Services registered with Consul that are tagged with their cluster name are now exposed as `conqueso.cluster.ips=x.x.x.x` on the `/v1/conqueso` end point. Services that don't have tags are exposed with the service name as the cluster name.