### PR TITLE
Consul source should not be shutdown on index update

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -82,15 +82,6 @@ class PluginManager extends EventEmitter {
       path: configuration.path || DEFAULT_INDEX_PATH,
       parser: new S3IndexParser()
     });
-    this.consul = configuration.consul || new Consul({
-      host: Config.get('consul:host'),
-      port: Config.get('consul:port'),
-      secure: Config.get('consul:secure')
-    });
-
-    // For now the Consul plugin will be loaded as a singleton rather than relying
-    // on being listed in the index document.
-    this._registerSource(this.consul);
 
     this.index.on('error', (error) => {
       this._error(error);
@@ -215,9 +206,17 @@ class PluginManager extends EventEmitter {
         // case 'file':
         //  //
         //  break;
-        // case 'consul':
-        //  //
-        //  break;
+        case 'consul':
+          const existingConsulSources = this.storage.sources.filter((el) => el.type === 'consul');
+
+          if (existingConsulSources.length <= 0) {
+            instance = new Consul({
+              host: Config.get('consul:host'),
+              port: Config.get('consul:port'),
+              secure: Config.get('consul:secure')
+            });
+          }
+          break;
         default:
           this._error(new Error(`Source type ${source.type} not implemented`));
       }

--- a/test/data/s3/index.json
+++ b/test/data/s3/index.json
@@ -21,6 +21,10 @@
       "parameters": {
         "path": "{{ instance:ami-id }}.json"
       }
+    },
+    {
+      "name": "consul",
+      "type": "consul"
     }
   ]
 }

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -212,7 +212,7 @@ describe('Plugin manager', function () {
     manager.initialize();
   });
 
-  before(() => {
+  it('only allows one instance of the consul source', (done) => {
     const indexWithMultipleConsulSources = JSON.parse(fakeIndexResponse.Body.toString());
 
     // Add a bunch of consul sources
@@ -223,8 +223,7 @@ describe('Plugin manager', function () {
       ETag: 'ThisIsADifferentETag',
       Body: new Buffer(JSON.stringify(indexWithMultipleConsulSources))
     });
-  });
-  it('only allows one instance of the consul source', (done) => {
+
     manager.on('source-registered', (instance) => {
       if (instance.type === 'consul') {
         // We need to stub all consul sources
@@ -244,9 +243,6 @@ describe('Plugin manager', function () {
     });
 
     manager.initialize();
-  });
-  after(() => {
-    AWS.S3 = _S3;
   });
 
   // SECOND PULL REQUEST

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -52,7 +52,12 @@ describe('Plugin manager', function () {
         return {name: s.name, type: s.type};
       });
 
-      sourceObjs.should.eql([{name: 'global', type: 's3'}, {name: 'account', type: 's3'}, {name: 'ami', type: 's3'}]);
+      sourceObjs.should.eql([
+        {name: 'global', type: 's3'},
+        {name: 'account', type: 's3'},
+        {name: 'ami', type: 's3'},
+        {name: 'consul', type: 'consul'}
+      ]);
       done();
     });
 
@@ -90,7 +95,12 @@ describe('Plugin manager', function () {
         return {name: s.name, type: s.type};
       });
 
-      sourceObjs.should.eql([{name: 'global', type: 's3'}, {name: 'account', type: 's3'}, {name: 'ami', type: 's3'}]);
+      sourceObjs.should.eql([
+        {name: 'global', type: 's3'},
+        {name: 'account', type: 's3'},
+        {name: 'ami', type: 's3'},
+        {name: 'consul', type: 'consul'}
+      ]);
       done();
     });
 
@@ -102,7 +112,7 @@ describe('Plugin manager', function () {
     manager.once('sources-registered', () => {
       const sourceNames = storage.sources.map((el) => el.name); // eslint-disable-line max-nested-callbacks
 
-      sourceNames.should.eql(['s3-foo-global.json', 's3-foo-account/12345.json', 's3-foo-ami-4aface7a.json']);
+      sourceNames.should.eql(['s3-foo-global.json', 's3-foo-account/12345.json', 's3-foo-ami-4aface7a.json', 'consul']);
       done();
     });
 
@@ -165,7 +175,7 @@ describe('Plugin manager', function () {
 
       status.running.should.be.true();
       status.ok.should.be.true();
-      sources.length.should.equal(3); // eslint-disable-line rapid7/static-magic-numbers
+      sources.length.should.equal(4); // eslint-disable-line rapid7/static-magic-numbers
       done();
     });
 
@@ -196,7 +206,7 @@ describe('Plugin manager', function () {
 
       status.running.should.be.true();
       status.ok.should.be.true();
-      sources.length.should.equal(3); // eslint-disable-line rapid7/static-magic-numbers
+      sources.length.should.equal(4); // eslint-disable-line rapid7/static-magic-numbers
       done();
     });
 


### PR DESCRIPTION
This resolves #79. The tradeoff is that the consul source needs to be enumerated in the index document in the correct location. The `PluginManager` will pick up the first occurrence of the source plugin and ignore all others so make sure that the consul plugin is positioned correctly in the index so it doesn't get overridden.