### PR TITLE
Fix: PluginManager TODO tests

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -199,7 +199,6 @@ class PluginManager extends EventEmitter {
    * @private
    */
   _registerSources(sources) {
-    // TODO: WRITE TESTS
     this.storage.clear();
 
     sources.forEach((source) => {

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -41,8 +41,11 @@ describe('Plugin manager', function () {
 
   afterEach(function () {
     manager.shutdown();
-    manager.listenerCount('error').should.eql(0);
-    manager.listenerCount('sources-registered').should.eql(0);
+
+    // Unregister listeners so tests error out cleanly.
+    manager.removeAllListeners('error');
+    manager.removeAllListeners('sources-registered');
+
     manager = null;
     storage = null;
     AWS.S3 = _S3;

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -255,18 +255,18 @@ describe('Plugin manager', function () {
   }); */
 
   it('exposes an error from source plugins when one occurs but continues running', function (done) {
-    manager.once('source-instantiated', (instance) => {
-      function onUnknownEndpoint(err) {
-        if (err.message === 'UnknownEndpoint') {
-          instance.removeListener('error', onUnknownEndpoint);
+    function onUnknownEndpoint(err) {
+      if (err.message === 'UnknownEndpoint') {
+        manager.removeListener('error', onUnknownEndpoint);
 
-          manager.status().running.should.be.true();
-          done();
-        }
+        manager.status().running.should.be.true();
+        done();
       }
+    }
 
-      instance.on('error', onUnknownEndpoint);
+    manager.on('error', onUnknownEndpoint);
 
+    manager.once('source-instantiated', () => {
       AWS.S3.prototype.getObject = sinon.stub().callsArgWith(1, unknownEndpointErr, null);
     });
 

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -386,4 +386,4 @@ describe('Plugin manager', function () {
   });
 });
 
-/* eslint-enable func-names */
+/* eslint-enable func-names, max-nested-callbacks */

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -252,23 +252,26 @@ describe('Plugin manager', function () {
     // TODO: Stub getObject to return an index that's missing one of the plugins, test that storage.sources contains
     // the updated plugins
     done();
-  });
+  }); */
 
   it('exposes an error from source plugins when one occurs but continues running', function (done) {
     manager.once('source-instantiated', (instance) => {
-      instance.on('error', (err) => {
-        const status = manager.status();
+      function onUnknownEndpoint(err) {
+        if (err.message === 'UnknownEndpoint') {
+          instance.removeListener('error', onUnknownEndpoint);
 
-        err.message.should.equal('UnknownEndpoint');
-        status.running.should.be.true();
-        done();
-      });
+          manager.status().running.should.be.true();
+          done();
+        }
+      }
+
+      instance.on('error', onUnknownEndpoint);
 
       AWS.S3.prototype.getObject = sinon.stub().callsArgWith(1, unknownEndpointErr, null);
     });
 
     manager.initialize();
-  }); */
+  });
 });
 
 /* eslint-enable func-names */

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -42,6 +42,7 @@ describe('Plugin manager', function () {
   afterEach(function () {
     manager.shutdown();
     manager.listenerCount('error').should.eql(0);
+    manager.listenerCount('sources-registered').should.eql(0);
     manager = null;
     storage = null;
     AWS.S3 = _S3;

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -182,8 +182,10 @@ describe('Plugin manager', function () {
   it('retries S3 source until it succeeds if the S3 source fails', function (done) {
     AWS.S3.prototype.getObject = sinon.stub().callsArgWith(1, unknownEndpointErr, null);
 
-    manager.on('error', (err) => {
+    function onUnknownEndpoint(err) {
       if (err.message === 'UnknownEndpoint') {
+        manager.removeListener('error', onUnknownEndpoint);
+
         const indexStatus = manager.index.status();
         const managerStatus = manager.status();
 
@@ -194,7 +196,9 @@ describe('Plugin manager', function () {
 
         AWS.S3.prototype.getObject = sinon.stub().callsArgWith(1, null, fakeIndexResponse);
       }
-    });
+    }
+
+    manager.on('error', onUnknownEndpoint);
 
     manager.once('sources-generated', (sources) => {
       const status = manager.status();


### PR DESCRIPTION
This adds more tests around the PluginManager. We make sure old plugins are shut down when the index changes. We also make sure plugins are added and removed when the index changes.