### PR TITLE
Fix: Can merge Consul plugin properties

### DIFF
--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -91,7 +91,7 @@ class Consul extends EventEmitter {
    * @param {Object} options  Options that can be set for the plugin
    */
   configure(options) {
-    const params = options || Object.create(null);
+    const params = options || {};
 
     this.host = params.host || DEFAULT_AGENT_ADDRESS;
     this.port = params.port || DEFAULT_AGENT_PORT;
@@ -102,8 +102,8 @@ class Consul extends EventEmitter {
    * Clear the underlying properties object
    */
   clear() {
-    this.properties = Object.create(null);
-    this.properties.consul = Object.create(null);
+    this.properties = {};
+    this.properties.consul = {};
   }
 
   /**
@@ -214,7 +214,7 @@ class Consul extends EventEmitter {
       });
 
       if (!this.properties.consul[name]) {
-        this.properties.consul[name] = Object.create(null);
+        this.properties.consul[name] = {};
       }
       this.properties.consul[name].addresses = addresses.sort();
       this.properties.consul[name].cluster = cluster;
@@ -248,7 +248,7 @@ class Consul extends EventEmitter {
    */
   _registerHealthWatcher(name, watcher) {
     if (!this._healthWatchers) {
-      this._healthWatchers = Object.create(null);
+      this._healthWatchers = {};
     }
     this._healthWatchers[name] = watcher;
   }

--- a/test/consul.js
+++ b/test/consul.js
@@ -504,7 +504,7 @@ describe('Storage engine', () => {
       Node: {Address: '10.0.0.0'}
     }]);
 
-    return Promise.resolve(storage.properties).should.eventually.eql({
+    return Promise.resolve(storage.properties.consul).should.eventually.eql({
       consul: {
         cluster: 'consul',
         addresses: ['10.0.0.0']


### PR DESCRIPTION
This fixes #80. Usage of `Object.create(null)` has been replaced with `{}` in the Consul plugin so the `hasOwnProperty` checks in the storage engine work correctly.