### PR TITLE
Fix logging levels

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -50,5 +50,5 @@ require('../lib/control/v1/core').attach(app, storage, manager);
 require('../lib/control/v1/conqueso').attach(app, storage);
 
 server.listen(port, host, () => {
-  Log.info('Listening on ' + host + ':' + port);
+  Log.info(`Listening on ${host}:${port}`);
 });

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -252,20 +252,20 @@ class PluginManager extends EventEmitter {
    */
   _registerSourceEvents(source) {
     source.on('startup', () => {
-      Log.info(`${source.name} started up.`);
+      Log.verbose(`${source.name} started up.`);
     });
 
     source.on('shutdown', () => {
-      Log.info(`${source.name} shut down.`);
+      Log.verbose(`${source.name} shut down.`);
     });
 
     source.on('update', () => {
-      Log.info(`${source.name}'s data was updated from its underlying source data.`);
+      Log.verbose(`${source.name}'s data was updated from its underlying source data.`);
       this.storage.update();
     });
 
     source.on('no-update', () => {
-      Log.info(`${source.name} has no update to its underlying source data.`);
+      Log.verbose(`${source.name} has no update to its underlying source data.`);
     });
 
     source.on('error', (err) => {

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -33,6 +33,11 @@ class Consul extends EventEmitter {
       return;
     }
 
+    Log.info(`Initializing ${this.type} source ${this.name}`, {
+      source: this.name,
+      type: this.type
+    });
+
     this._consul = consul({
       host: this.host,
       port: this.port,
@@ -62,6 +67,11 @@ class Consul extends EventEmitter {
     this._shutdownHealthWatchers();
     this._shutdownServiceWatcher();
     delete this._consul;
+
+    Log.info(`Shutting down ${this.type} source ${this.name}`, {
+      source: this.name,
+      type: this.type
+    });
 
     this._okay = false;
     this.emit('shutdown');
@@ -226,6 +236,12 @@ class Consul extends EventEmitter {
 
     this._okay = true;
     this._updated = new Date();
+
+    Log.info(`Updated source ${this.name}`, {
+      source: this.name,
+      type: this.type
+    });
+
     this.emit('update', this);
   }
 

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -239,7 +239,9 @@ class Consul extends EventEmitter {
 
     Log.info(`Updated source ${this.name}`, {
       source: this.name,
-      type: this.type
+      type: this.type,
+      name,
+      cluster
     });
 
     this.emit('update', this);

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -412,7 +412,7 @@ class Metadata extends EventEmitter {
     this._updated = new Date();
     this._ok = true;
 
-    Log.info('Updated source ' + this.name, {
+    Log.info(`Updated source ${this.name}`, {
       source: this.name,
       type: this.type
     });

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -230,10 +230,6 @@ class S3 extends EventEmitter {
           return callback(null, false);
         }
 
-        Log.error(err, {
-          source: _this.name,
-          type: _this.type
-        });
         return callback(err);
       }
 

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -255,7 +255,7 @@ class S3 extends EventEmitter {
     this._updated = new Date();
     this._ok = true;
 
-    Log.info('Updated source ' + this.name, {
+    Log.info(`Updated source ${this.name}`, {
       source: this.name,
       type: this.type
     });


### PR DESCRIPTION
Addresses #82. Changed some logging levels to be more significant. Operations (startup, shutdown, update) should be logged as `info` from their respective source. Source status information emitted from the `PluginManager` are logged as `verbose` to maintain some separation from `debug` level logging which is fired during source polling.

I also updated the consul source so that it's logging is a little bit more meaningful.