### PR TITLE
Fix: Remove translated Consul properties

### DIFF
--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -6,6 +6,39 @@ const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
 
 /**
+ * Deep copy an object
+ * https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+ *
+ * @param {Object} object  The object to be copied
+ * @return {Object}        A deep copy of the provided object
+ */
+function clone(object) {
+  if (!(object instanceof Object)) {
+    return object;
+  }
+
+  const Constructor = object.constructor;
+  let clonedObject = null;
+
+  switch (Constructor) {
+    case RegExp:
+      clonedObject = new Constructor(object);
+      break;
+    case Date:
+      clonedObject = new Constructor(object.getTime());
+      break;
+    default:
+      clonedObject = new Constructor();
+  }
+
+  for (const key in object) { // eslint-disable-line guard-for-in
+    clonedObject[key] = clone(object[key]);
+  }
+
+  return clonedObject;
+}
+
+/**
  * Format the given data as Java properties
  *
  * @param {Object} data
@@ -49,7 +82,6 @@ function translateConquesoAddresses(properties) {
       properties[`conqueso.${cluster}.ips`] = properties.consul[service].addresses.join(',');
     });
     delete properties.consul;
-
   }
 
   /* eslint-enable no-param-reassign */
@@ -63,7 +95,7 @@ function translateConquesoAddresses(properties) {
  * @return {String}            Flattened Java properties as returned by Conqueso
  */
 function makeConquesoProperties(properties) {
-  let results = Object.assign({}, properties);
+  let results = clone(properties);
 
   results = translateConquesoAddresses(results);
   results = flatten(results);

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -41,18 +41,19 @@ function makeJavaProperties(data) {
  * @return {Object}            Properties with Consul address converted to Conqueso ones
  */
 function translateConquesoAddresses(properties) {
-  const conquesoIps = Object.create(null);
-
   if (properties.consul) {
     Object.keys(properties.consul).forEach((service) => {
       const cluster = properties.consul[service].cluster;
 
-      conquesoIps[`conqueso.${cluster}.ips`] = properties.consul[service].addresses.join(',');
+  /* eslint-disable no-param-reassign */
+      properties[`conqueso.${cluster}.ips`] = properties.consul[service].addresses.join(',');
     });
-    delete properties.consul; // eslint-disable-line no-param-reassign
+    delete properties.consul;
+
   }
 
-  return Object.assign(properties, conquesoIps);
+  /* eslint-enable no-param-reassign */
+  return properties;
 }
 
 /**
@@ -62,8 +63,9 @@ function translateConquesoAddresses(properties) {
  * @return {String}            Flattened Java properties as returned by Conqueso
  */
 function makeConquesoProperties(properties) {
-  let results = translateConquesoAddresses(properties);
+  let results = Object.assign({}, properties);
 
+  results = translateConquesoAddresses(results);
   results = flatten(results);
 
   return makeJavaProperties(results);

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -48,6 +48,7 @@ function injectConquesoAddresses(properties) {
 
       conquesoIps[`conqueso.${cluster}.ips`] = properties.consul[service].addresses.join(',');
     });
+    delete properties.consul; // eslint-disable-line no-param-reassign
   }
 
   return Object.assign(properties, conquesoIps);

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -25,6 +25,7 @@ function makeJavaProperties(data) {
 
 /**
  * Converts Consul addresess to Conqueso addresses
+ * Warning! Original Consul properties are removed
  *
  * Addresses returned by the Consul plugin are formatted as
  * {
@@ -39,7 +40,7 @@ function makeJavaProperties(data) {
  * @param {Object} properties  Properties as returned from Storage#properties
  * @return {Object}            Properties with Consul address converted to Conqueso ones
  */
-function injectConquesoAddresses(properties) {
+function translateConquesoAddresses(properties) {
   const conquesoIps = Object.create(null);
 
   if (properties.consul) {
@@ -61,7 +62,7 @@ function injectConquesoAddresses(properties) {
  * @return {String}            Flattened Java properties as returned by Conqueso
  */
 function makeConquesoProperties(properties) {
-  let results = injectConquesoAddresses(properties);
+  let results = translateConquesoAddresses(properties);
 
   results = flatten(results);
 

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -5,6 +5,7 @@ const generateConsulStub = require('./utils/consul-stub');
 const request = require('supertest');
 
 const testServerPort = 3000;
+const fixedDate = new Date();
 
 const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
@@ -15,6 +16,7 @@ const conquesoProperties = {
     'meta.property.2': 'artisanal cream cheese'
   },
   properties: {
+    date: fixedDate,
     name: 'hipster-mode-enabled',
     value: true,
     type: 'BOOLEAN'
@@ -38,9 +40,20 @@ const nestedProperties = {
   }
 };
 
-const javaProperties = 'name=hipster-mode-enabled\nvalue=true\ntype=BOOLEAN';
-const nestedJavaProperties = 'name=hipster-mode-enabled\nvalue=true\ntype=BOOLEAN\nfood.name=tacos\n' +
-    'food.value=true\nfood.type=BOOLEAN';
+const javaProperties = [
+  `date=${fixedDate}`,
+  'name=hipster-mode-enabled',
+  'value=true',
+  'type=BOOLEAN'
+].join('\n');
+const nestedJavaProperties = [
+  'name=hipster-mode-enabled',
+  'value=true',
+  'type=BOOLEAN',
+  'food.name=tacos',
+  'food.value=true',
+  'food.type=BOOLEAN'
+].join('\n');
 
 /**
  * Create a new Express server for testing
@@ -230,4 +243,5 @@ describe('Conqueso API v1', () => {
       Service: {Address: '127.0.0.1'}
     }]);
   });
+
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -6,6 +6,7 @@ const request = require('supertest');
 
 const testServerPort = 3000;
 const fixedDate = new Date();
+const fixedRegex = /ab+c/i;
 
 const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
@@ -17,6 +18,7 @@ const conquesoProperties = {
   },
   properties: {
     date: fixedDate,
+    regex: fixedRegex,
     name: 'hipster-mode-enabled',
     value: true,
     type: 'BOOLEAN'
@@ -42,6 +44,7 @@ const nestedProperties = {
 
 const javaProperties = [
   `date=${fixedDate}`,
+  'regex=/ab+c/i',
   'name=hipster-mode-enabled',
   'value=true',
   'type=BOOLEAN'

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -163,7 +163,7 @@ describe('Conqueso API v1', () => {
 
       consul.properties.should.eql({
         consul: {
-          'elasticsearch': {
+          elasticsearch: {
             addresses: ['10.0.0.0', '127.0.0.1'],
             cluster: 'elasticsearch'
           }

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -156,12 +156,29 @@ describe('Conqueso API v1', () => {
       'conqueso.elasticsearch.ips=10.0.0.0,127.0.0.1'
     ].join('\n');
 
+    function checkConsulProperties(err) {
+      if (err) {
+        return done(err);
+      }
+
+      consul.properties.should.eql({
+        consul: {
+          'elasticsearch': {
+            addresses: ['10.0.0.0', '127.0.0.1'],
+            cluster: 'elasticsearch'
+          }
+        }
+      });
+
+      done();
+    }
+
     consul.on('update', () => {
       request(server)
         .get('/v1/conqueso/api/roles')
         .set('Accept', 'text/plain')
         .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(HTTP_OK, expectedBody, done);
+        .expect(HTTP_OK, expectedBody, checkConsulProperties);
     });
 
     consul.mock.emitChange('catalog-service', {
@@ -179,12 +196,29 @@ describe('Conqueso API v1', () => {
       'conqueso.sweet-es-cluster.ips=10.0.0.0,127.0.0.1'
     ].join('\n');
 
+    function checkConsulProperties(err) {
+      if (err) {
+        return done(err);
+      }
+
+      consul.properties.should.eql({
+        consul: {
+          'elasticsearch-sweet-es-cluster': {
+            addresses: ['10.0.0.0', '127.0.0.1'],
+            cluster: 'sweet-es-cluster'
+          }
+        }
+      });
+
+      done();
+    }
+
     consul.on('update', () => {
       request(server)
         .get('/v1/conqueso/api/roles')
         .set('Accept', 'text/plain')
         .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(HTTP_OK, expectedBody, done);
+        .expect(HTTP_OK, expectedBody, checkConsulProperties);
     });
 
     consul.mock.emitChange('catalog-service', {

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -246,5 +246,4 @@ describe('Conqueso API v1', () => {
       Service: {Address: '127.0.0.1'}
     }]);
   });
-
 });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -153,9 +153,6 @@ describe('Conqueso API v1', () => {
 
   it('formats IP addresses for untagged Consul services', (done) => {
     const expectedBody = [
-      'consul.elasticsearch.addresses.0=10.0.0.0',
-      'consul.elasticsearch.addresses.1=127.0.0.1',
-      'consul.elasticsearch.cluster=elasticsearch',
       'conqueso.elasticsearch.ips=10.0.0.0,127.0.0.1'
     ].join('\n');
 
@@ -179,9 +176,6 @@ describe('Conqueso API v1', () => {
 
   it('formats IP addresses for tagged Consul services', (done) => {
     const expectedBody = [
-      'consul.elasticsearch-sweet-es-cluster.addresses.0=10.0.0.0',
-      'consul.elasticsearch-sweet-es-cluster.addresses.1=127.0.0.1',
-      'consul.elasticsearch-sweet-es-cluster.cluster=sweet-es-cluster',
       'conqueso.sweet-es-cluster.ips=10.0.0.0,127.0.0.1'
     ].join('\n');
 


### PR DESCRIPTION
This fixes #90. Consul properties that have been translated into the Conqueso compatibility layer are removed from the formatted output.