### PR TITLE
Fix ordering ips in conqueso diff

### DIFF
--- a/test/bin/conqueso-diff
+++ b/test/bin/conqueso-diff
@@ -7,26 +7,28 @@
 const HTTP = require('http');
 const ONE_MINUTE = 60000;
 
-function requestProperties(uri, callback) {
-  console.log('Polling ' + uri);
-  const req = HTTP.get(uri, (res) => {
-    res.setEncoding('utf8');
+function requestProperties(uri) {
+  console.log(`Polling ${uri}`);
+  return new Promise((resolve, reject) => {
+    const req = HTTP.get(uri, (res) => {
+      res.setEncoding('utf8');
 
-    let data = '';
+      let data = '';
 
-    res.on('data', (d) => {
-      data += d;
+      res.on('data', (d) => {
+        data += d;
+      });
+
+      res.on('error', reject);
+
+      res.on('end', (d) => {
+        if (d) data += d;
+        resolve(data.split(/\n/g));
+      });
     });
 
-    res.on('error', callback);
-
-    res.on('end', (d) => {
-      if (d) data += d;
-      callback(null, data.split(/\n/g));
-    });
+    req.on('error', reject);
   });
-
-  req.on('error', callback);
 }
 
 function compareProperties(a, b) {
@@ -61,32 +63,29 @@ const CONQUESO = process.argv[2];
 const PROPSD = 'http://localhost:9100/v1/conqueso';
 
 (function poll() {
-  requestProperties(CONQUESO, (err0, conqueso) => {
-    if (err0) {
-      console.error(err0);
+  Promise.all([
+    requestProperties(CONQUESO),
+    requestProperties(PROPSD)
+  ])
+  .then((data) => {
+    const conqueso = data[0];
+    const propsd = data[1];
+
+    const diff = compareProperties(conqueso, propsd);
+
+    if (!different(diff)) {
+      return console.log('Properties are identical');
     }
 
-    requestProperties(PROPSD, (err1, propsd) => {
-      if (err1) {
-        console.error(err1);
-      }
-
-      const diff = compareProperties(conqueso, propsd);
-
-      if (!different(diff)) {
-        return console.log('Properties are identical');
-      }
-
-      console.log('Properties are not identical!');
-      diff.added.forEach((p) => {
-        console.log(`  + ${p}`);
-      });
-
-      diff.removed.forEach((p) => {
-        console.log(`  - ${p}`);
-      });
+    console.log('Properties are not identical!');
+    diff.added.forEach((p) => {
+      console.log(`  + ${p}`);
     });
-  });
+
+    diff.removed.forEach((p) => {
+      console.log(`  - ${p}`);
+    });
+  }, (err) => { console.error(err); });
 
   setTimeout(poll, ONE_MINUTE);
 }());

--- a/test/bin/conqueso-diff
+++ b/test/bin/conqueso-diff
@@ -7,6 +7,7 @@
 const HTTP = require('http');
 const ONE_MINUTE = 60000;
 
+/* eslint-disable no-console */
 function requestProperties(uri) {
   console.log(`Polling ${uri}`);
   return new Promise((resolve, reject) => {
@@ -31,9 +32,27 @@ function requestProperties(uri) {
   });
 }
 
+/**
+ * Sort values that are comma-delimited
+ * @param {Array} arr
+ * @returns {Array}
+ */
+function sortDelimitedValues(arr) {
+  arr.forEach((el, i) => {
+    const splitProp = el.split('=');
+    let val = splitProp[1];
+
+    if (val.split(',').length > 1) {
+      val = val.split(',').sort();
+    }
+    arr[i] = [splitProp[0], val].join('='); // eslint-disable-line no-param-reassign
+  });
+  return arr;
+}
+
 function compareProperties(a, b) {
-  a = a.sort(); // eslint-disable-line no-param-reassign
-  b = b.sort(); // eslint-disable-line no-param-reassign
+  a = sortDelimitedValues(a.sort()); // eslint-disable-line no-param-reassign
+  b = sortDelimitedValues(b.sort()); // eslint-disable-line no-param-reassign
 
   const difference = {
     added: [],
@@ -89,3 +108,5 @@ const PROPSD = 'http://localhost:9100/v1/conqueso';
 
   setTimeout(poll, ONE_MINUTE);
 }());
+
+/* eslint-enable no-console */

--- a/test/bin/conqueso-diff
+++ b/test/bin/conqueso-diff
@@ -1,29 +1,26 @@
 #!/usr/bin/env node
-
-/* eslint-disable curly, func-names, no-param-reassign, no-unused-func,
-                  newline-after-var, no-var, one-var, vars-on-top, no-unused-vars,
-                  no-bitwise, no-console, wrap-iife, max-nested-callbacks
-*/
+'use strict';
 
 /**
  * Poll Conqueso and propsd to test for interface inconsistencies
  */
-var HTTP = require('http');
+const HTTP = require('http');
 const ONE_MINUTE = 60000;
 
 function requestProperties(uri, callback) {
   console.log('Polling ' + uri);
-  var req = HTTP.get(uri, function (res) {
+  const req = HTTP.get(uri, (res) => {
     res.setEncoding('utf8');
 
-    var data = '';
-    res.on('data', function (d) {
+    let data = '';
+
+    res.on('data', (d) => {
       data += d;
     });
 
     res.on('error', callback);
 
-    res.on('end', function (d) {
+    res.on('end', (d) => {
       if (d) data += d;
       callback(null, data.split(/\n/g));
     });
@@ -33,19 +30,25 @@ function requestProperties(uri, callback) {
 }
 
 function compareProperties(a, b) {
-  a = a.sort();
-  b = b.sort();
+  a = a.sort(); // eslint-disable-line no-param-reassign
+  b = b.sort(); // eslint-disable-line no-param-reassign
 
-  var difference = {
+  const difference = {
     added: [],
     removed: []
   };
 
-  for (var i = 0; i < b.length; i++)
-    if (!~(a.indexOf(b[i]))) difference.added.push(b[i]);
+  for (let i = 0; i < b.length; i++) {
+    if (!~(a.indexOf(b[i]))) { // eslint-disable-line no-bitwise
+      difference.added.push(b[i]);
+    }
+  }
 
-  for (var j = 0; j < a.length; j++)
-    if (!~(b.indexOf(a[j]))) difference.removed.push(a[j]);
+  for (let j = 0; j < a.length; j++) {
+    if (!~(b.indexOf(a[j]))) { // eslint-disable-line no-bitwise
+      difference.removed.push(a[j]);
+    }
+  }
 
   return difference;
 }
@@ -54,30 +57,36 @@ function different(difference) {
   return difference.added.length > 0 || difference.removed.length > 0;
 }
 
-var CONQUESO = process.argv[2];
-var PROPSD = 'http://localhost:9100/v1/conqueso';
+const CONQUESO = process.argv[2];
+const PROPSD = 'http://localhost:9100/v1/conqueso';
 
 (function poll() {
-  requestProperties(CONQUESO, function (err0, conqueso) {
-    if (err0) console.error(err0);
+  requestProperties(CONQUESO, (err0, conqueso) => {
+    if (err0) {
+      console.error(err0);
+    }
 
-    requestProperties(PROPSD, function (err1, propsd) {
-      if (err1) console.error(err1);
+    requestProperties(PROPSD, (err1, propsd) => {
+      if (err1) {
+        console.error(err1);
+      }
 
-      var diff = compareProperties(conqueso, propsd);
+      const diff = compareProperties(conqueso, propsd);
 
-      if (!different(diff)) return console.log('Properties are identical');
+      if (!different(diff)) {
+        return console.log('Properties are identical');
+      }
 
       console.log('Properties are not identical!');
-      diff.added.forEach(function (p) {
-        console.log('  + ' + p);
+      diff.added.forEach((p) => {
+        console.log(`  + ${p}`);
       });
 
-      diff.removed.forEach(function (p) {
-        console.log('  - ' + p);
+      diff.removed.forEach((p) => {
+        console.log(`  - ${p}`);
       });
     });
   });
 
   setTimeout(poll, ONE_MINUTE);
-})();
+}());


### PR DESCRIPTION
This PR resolves an issue in the `conqueso-diff` tool where values that were lists (IPs, etc.) weren't being sorted and were showing as false positives.