### PR TITLE
Fix: conqueso diff property parsing

### DIFF
--- a/test/bin/conqueso-diff
+++ b/test/bin/conqueso-diff
@@ -75,8 +75,8 @@ Array.prototype.truncateNumericProperties = function truncateNumericProperties()
 /* eslint-enable no-extend-native */
 
 function compareProperties(a, b) {
-  a = sortDelimitedValues(a.sort()); // eslint-disable-line no-param-reassign
-  b = sortDelimitedValues(b.sort()); // eslint-disable-line no-param-reassign
+  a = a.sort().sortDelimitedValues().truncateNumericProperties(); // eslint-disable-line no-param-reassign
+  b = b.sort().sortDelimitedValues().truncateNumericProperties(); // eslint-disable-line no-param-reassign
 
   const difference = {
     added: [],

--- a/test/bin/conqueso-diff
+++ b/test/bin/conqueso-diff
@@ -33,22 +33,46 @@ function requestProperties(uri) {
 }
 
 /**
- * Sort values that are comma-delimited
+ * Apply an operation to each value of a conqueso property if it passes a comparator
  * @param {Array} arr
+ * @param {Function} comparator
+ * @param {Function} operation
  * @returns {Array}
  */
-function sortDelimitedValues(arr) {
+function apply(arr, comparator, operation) {
+  const ret = [];
+
   arr.forEach((el, i) => {
     const splitProp = el.split('=');
+    const prop = splitProp[0];
     let val = splitProp[1];
 
-    if (val.split(',').length > 1) {
-      val = val.split(',').sort();
+    if (comparator(val)) {
+      val = operation(val);
     }
-    arr[i] = [splitProp[0], val].join('='); // eslint-disable-line no-param-reassign
+    ret[i] = `${prop}=${val}`;
   });
-  return arr;
+  return ret;
 }
+
+/* eslint-disable no-extend-native */
+/**
+ * Sort values that are comma-delimited
+ * @returns {Array}
+ */
+Array.prototype.sortDelimitedValues = function sortDelimitedValues() {
+  return apply(this, (val) => val.split(',').length > 1, (val) => val.split(',').sort());
+};
+
+/**
+ * Truncates numeric properties for conqueso property string float -> js float comparison
+ * @returns {Array}
+ */
+Array.prototype.truncateNumericProperties = function truncateNumericProperties() {
+  return apply(this, (val) => !isNaN(val) && isFinite(val), (val) => parseFloat(val));
+};
+
+/* eslint-enable no-extend-native */
 
 function compareProperties(a, b) {
   a = sortDelimitedValues(a.sort()); // eslint-disable-line no-param-reassign


### PR DESCRIPTION
This PR applies some transformation and sorting around properties so that we don't see false positives in the diff output.

Specifically, it sorts IP addresses (conqueso doesn't sort by default) and handles JavaScript trying to be helpful when it truncates `75.0.toString()` to `'75'`.

Archaius maps properties to Java types and reads all values from the conqueso/propsd endpoint as strings anyway, so the diffs produced by this tool truncate values with trailing zeroes that are produced by conqueso in the interest of matching values correctly.