### PR TITLE
Fix: refactored service list watcher and service health watcher parsing into their own classes

### DIFF
--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -31,6 +31,47 @@ class ConquesoCompatHealthParser {
     this.properties = properties;
   }
 }
+
+class ConquesoCompatServiceParser {
+  constructor() {
+    this.properties = {};
+  }
+
+  update(data, callback) {
+    const services = Object.keys(data);
+    const watcherInfo = [];
+
+    services.forEach((service) => {
+      const tags = data[service];
+
+      tags.forEach((tag) => {
+        watcherInfo.push({
+          name: `${service}-${tag}`,
+          cluster: tag,
+          options: {
+            passing: true,
+            service,
+            tag
+          }
+        });
+      });
+
+      if (tags.length <= 0) {
+        watcherInfo.push({
+          name: service,
+          cluster: service,
+          options: {
+            passing: true,
+            service
+          }
+        });
+      }
+    });
+
+    this.properties.watcherInfo = watcherInfo.filter(callback);
+  }
+}
+
 class Consul extends EventEmitter {
   /**
    * Creates a new instance of a Consul souce plugin
@@ -47,6 +88,7 @@ class Consul extends EventEmitter {
     this.name = 'consul';
     this._okay = false;
     this._updated = null;
+    this._serviceParser = new ConquesoCompatServiceParser();
   }
 
   /**
@@ -162,41 +204,8 @@ class Consul extends EventEmitter {
    * @private
    */
   _onServiceListChange(data) {
-    const services = Object.keys(data);
-    const watcherInfo = [];
-
-    services.forEach((service) => {
-      const tags = data[service];
-
-      tags.forEach((tag) => {
-        watcherInfo.push({
-          name: `${service}-${tag}`,
-          cluster: tag,
-          options: {
-            passing: true,
-            service,
-            tag
-          }
-        });
-      });
-
-      if (tags.length <= 0) {
-        watcherInfo.push({
-          name: service,
-          cluster: service,
-          options: {
-            passing: true,
-            service
-          }
-        });
-      }
-    });
-
-    const newWatchers = watcherInfo.filter((info) => {
-      return !this._hasHealthWatcher(info.name);
-    });
-
-    newWatchers.forEach((info) => {
+    this._serviceParser.update(data, (info) => !this._hasHealthWatcher(info.name));
+    this._serviceParser.properties.watcherInfo.forEach((info) => {
       const watcher = this._consul.watch({
         method: this._consul.health.service,
         options: info.options

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -12,6 +12,22 @@ class ConquesoCompatHealthParser {
     this.properties = {};
   }
 
+  /**
+   * Parse data from the Consul health watcher
+   *
+   * The data returned from Consul looks like this:
+   * [{
+   *   "Node": {
+   *     "Address": "127.0.0.1"
+   *   },
+   *   "Service": {
+   *     "Address": "10.0.0.0"
+   *   }
+   * }]
+   *
+   * @param {Array} data
+   * @param {String} cluster
+   */
   update(data, cluster) {
     const properties = {};
     const addresses = [];
@@ -37,6 +53,18 @@ class ConquesoCompatServiceParser {
     this.properties = {};
   }
 
+  /**
+   * Parse data from the Consul service list watcher
+   *
+   * The data returned from Consul looks like this:
+   * {
+   *   "service-name": ['tag', 'tag'],
+   *   "other-service-name": ['other-tag', 'other-tag'],
+   * }
+   *
+   * @param {Object} data
+   * @param {Function} callback Optional function to filter the
+   */
   update(data, callback) {
     const services = Object.keys(data);
     const watcherInfo = [];
@@ -227,16 +255,6 @@ class Consul extends EventEmitter {
 
   /**
    * Process updates from Consul's health/service API.
-   *
-   * The data returned from Consul looks like this:
-   * [{
-   *   "Node": {
-   *     "Address": "127.0.0.1"
-   *   },
-   *   "Service": {
-   *     "Address": "10.0.0.0"
-   *   }
-   * }]
    *
    * @param {String} name     The name of the watcher
    * @param {String} cluster  The name of the clustered service

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -278,7 +278,7 @@ class Consul extends EventEmitter {
    * @private
    */
   _hasHealthWatcher(name) {
-    return this._healthWatchers && this._healthWatchers[name].watcher;
+    return this._healthWatchers && this._healthWatchers[name] && this._healthWatchers[name].watcher;
   }
 
   /**

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -67,7 +67,7 @@ class ConquesoCompatServiceParser {
    */
   update(data, callback) {
     const services = Object.keys(data);
-    const watcherInfo = [];
+    let watcherInfo = [];
 
     services.forEach((service) => {
       const tags = data[service];
@@ -96,7 +96,10 @@ class ConquesoCompatServiceParser {
       }
     });
 
-    this.properties.watcherInfo = watcherInfo.filter(callback);
+    if (callback && callback instanceof Function) {
+      watcherInfo = watcherInfo.filter(callback);
+    }
+    this.properties.watcherInfo = watcherInfo;
   }
 }
 

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -7,6 +7,30 @@ const consul = require('consul');
 const DEFAULT_AGENT_ADDRESS = '127.0.0.1';
 const DEFAULT_AGENT_PORT = 8500;
 
+class ConquesoCompatHealthParser {
+  constructor() {
+    this.properties = {};
+  }
+
+  update(data, cluster) {
+    const properties = {};
+    const addresses = [];
+
+    data.forEach((info) => {
+      // Prefer the service address, not the Consul agent address.
+      if (info.Service && info.Service.Address) {
+        addresses.push(info.Service.Address);
+      } else if (info.Node && info.Node.Address) {
+        addresses.push(info.Node.Address);
+      }
+    });
+
+    properties.addresses = addresses.sort();
+    properties.cluster = cluster;
+
+    this.properties = properties;
+  }
+}
 class Consul extends EventEmitter {
   /**
    * Creates a new instance of a Consul souce plugin
@@ -212,22 +236,12 @@ class Consul extends EventEmitter {
    */
   _onHealthServiceChange(name, cluster, data) {
     if (data.length > 0) {
-      const addresses = [];
-
-      data.forEach((info) => {
-        // Prefer the service address, not the Consul agent address.
-        if (info.Service && info.Service.Address) {
-          addresses.push(info.Service.Address);
-        } else if (info.Node && info.Node.Address) {
-          addresses.push(info.Node.Address);
-        }
-      });
+      this._healthWatchers[name].parser.update(data, cluster);
 
       if (!this.properties.consul[name]) {
         this.properties.consul[name] = {};
       }
-      this.properties.consul[name].addresses = addresses.sort();
-      this.properties.consul[name].cluster = cluster;
+      this.properties.consul[name] = this._healthWatchers[name].parser.properties;
     } else {
       // Empty data means the service has been deregistered.
       this._unregisterHealthWatcher(name);
@@ -255,7 +269,7 @@ class Consul extends EventEmitter {
    * @private
    */
   _hasHealthWatcher(name) {
-    return this._healthWatchers && this._healthWatchers[name];
+    return this._healthWatchers && this._healthWatchers[name].watcher;
   }
 
   /**
@@ -268,7 +282,10 @@ class Consul extends EventEmitter {
     if (!this._healthWatchers) {
       this._healthWatchers = {};
     }
-    this._healthWatchers[name] = watcher;
+    this._healthWatchers[name] = {
+      watcher,
+      parser: new ConquesoCompatHealthParser()
+    };
   }
 
   /**
@@ -278,7 +295,7 @@ class Consul extends EventEmitter {
    */
   _unregisterHealthWatcher(name) {
     if (this._hasHealthWatcher(name)) {
-      this._healthWatchers[name].end();
+      this._healthWatchers[name].watcher.end();
       delete this._healthWatchers[name];
     }
   }


### PR DESCRIPTION
This PR is the first of a few to cover #103. It focuses on refactoring watcher data parsing into their own classes, prefixed with `ConquesoCompat` to indicate their intermediate status. When consul tagging is complete we can refactor that class (or create new ones that conform to the interface) to migrate to our new methodology.

This PR resolves #69 and #70.