### PR TITLE
Consul source only uses service name

### DIFF
--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -63,41 +63,25 @@ class ConquesoCompatServiceParser {
    * }
    *
    * @param {Object} data
-   * @param {Function} callback Optional function to filter the
+   * @param {Function} filterCallback Optional function to filter health watchers before they're created
    */
-  update(data, callback) {
+  update(data, filterCallback) {
     const services = Object.keys(data);
     let watcherInfo = [];
 
     services.forEach((service) => {
-      const tags = data[service];
-
-      tags.forEach((tag) => {
-        watcherInfo.push({
-          name: `${service}-${tag}`,
-          cluster: tag,
-          options: {
-            passing: true,
-            service,
-            tag
-          }
-        });
+      watcherInfo.push({
+        name: service,
+        cluster: service,
+        options: {
+          passing: true,
+          service
+        }
       });
-
-      if (tags.length <= 0) {
-        watcherInfo.push({
-          name: service,
-          cluster: service,
-          options: {
-            passing: true,
-            service
-          }
-        });
-      }
     });
 
-    if (callback && callback instanceof Function) {
-      watcherInfo = watcherInfo.filter(callback);
+    if (filterCallback && filterCallback instanceof Function) {
+      watcherInfo = watcherInfo.filter(filterCallback);
     }
     this.properties.watcherInfo = watcherInfo;
   }
@@ -105,7 +89,7 @@ class ConquesoCompatServiceParser {
 
 class Consul extends EventEmitter {
   /**
-   * Creates a new instance of a Consul souce plugin
+   * Creates a new instance of a Consul source plugin
    * See the Consul#configure method for a list of valid options
    *
    * @param {Object} options  Options that can be set for the plugin

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -209,7 +209,7 @@ describe('Conqueso API v1', () => {
 
   it('formats IP addresses for tagged Consul services', (done) => {
     const expectedBody = [
-      'conqueso.sweet-es-cluster.ips=10.0.0.0,127.0.0.1'
+      'conqueso.elasticsearch.ips=10.0.0.0,127.0.0.1'
     ].join('\n');
 
     function checkConsulProperties(err) {
@@ -219,9 +219,9 @@ describe('Conqueso API v1', () => {
 
       consul.properties.should.eql({
         consul: {
-          'elasticsearch-sweet-es-cluster': {
+          elasticsearch: {
             addresses: ['10.0.0.0', '127.0.0.1'],
-            cluster: 'sweet-es-cluster'
+            cluster: 'elasticsearch'
           }
         }
       });
@@ -240,7 +240,7 @@ describe('Conqueso API v1', () => {
     consul.mock.emitChange('catalog-service', {
       elasticsearch: ['sweet-es-cluster']
     });
-    consul.mock.emitChange('elasticsearch-sweet-es-cluster', [{
+    consul.mock.emitChange('elasticsearch', [{
       Service: {Address: '10.0.0.0'}
     }, {
       Service: {Address: '127.0.0.1'}

--- a/test/consul.js
+++ b/test/consul.js
@@ -460,4 +460,8 @@ describe('Storage engine', () => {
       }
     });
   });
+
+  it('resolves multiple tags as separate services');
+
+  it('avoids resolving similar tags to the same service');
 });

--- a/test/consul.js
+++ b/test/consul.js
@@ -346,57 +346,6 @@ describe('Consul', () => {
     });
   });
 
-  it('resolves multiple tags as separate services', () => {
-    const consul = generateConsulStub();
-
-    consul.initialize();
-    consul.mock.emitChange('catalog-service', {consul: ['production', 'development']});
-    consul.mock.emitChange('consul-production', [{
-      Service: {Address: '127.0.0.1'}
-    }]);
-    consul.mock.emitChange('consul-development', [{
-      Service: {Address: '10.0.0.0'}
-    }]);
-
-    return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      'consul-production': {
-        cluster: 'production',
-        addresses: ['127.0.0.1']
-      },
-      'consul-development': {
-        cluster: 'development',
-        addresses: ['10.0.0.0']
-      }
-    });
-  });
-
-  it('avoids resolving similar tags to the same service', () => {
-    const consul = generateConsulStub();
-
-    consul.initialize();
-    consul.mock.emitChange('catalog-service', {
-      consul: ['production'],
-      elasticsearch: ['production']
-    });
-    consul.mock.emitChange('consul-production', [{
-      Service: {Address: '127.0.0.1'}
-    }]);
-    consul.mock.emitChange('elasticsearch-production', [{
-      Service: {Address: '10.0.0.0'}
-    }]);
-
-    return Promise.resolve(consul.properties.consul).should.eventually.eql({
-      'consul-production': {
-        cluster: 'production',
-        addresses: ['127.0.0.1']
-      },
-      'elasticsearch-production': {
-        cluster: 'production',
-        addresses: ['10.0.0.0']
-      }
-    });
-  });
-
   it('registers a watch on services when initialized', () => {
     const consul = generateConsulStub();
 
@@ -422,7 +371,7 @@ describe('Consul', () => {
     });
 
     return Promise.resolve(consul.mock.watching).should.eventually.eql(
-      ['catalog-service', 'consul-production', 'elasticsearch-production']
+      ['catalog-service', 'consul', 'elasticsearch']
     );
   });
 
@@ -434,10 +383,10 @@ describe('Consul', () => {
       consul: ['production'],
       elasticsearch: ['production']
     });
-    consul.mock.emitChange('consul-production', []);
+    consul.mock.emitChange('consul', []);
 
     return Promise.resolve(consul.mock.watching).should.eventually.eql(
-      ['catalog-service', 'elasticsearch-production']
+      ['catalog-service', 'elasticsearch']
     );
   });
 
@@ -445,7 +394,7 @@ describe('Consul', () => {
     const consul = generateConsulStub();
 
     consul.on('update', () => {
-      should(consul.mock.watching).eql(['catalog-service', 'consul-production']);
+      should(consul.mock.watching).eql(['catalog-service', 'consul']);
       consul.shutdown();
       should(consul.mock.watching).eql([]);
       done();
@@ -456,7 +405,7 @@ describe('Consul', () => {
       consul: ['production'],
       elasticsearch: ['production']
     });
-    consul.mock.emitChange('elasticsearch-production', []);
+    consul.mock.emitChange('elasticsearch', []);
   });
 
   it('emits itself on update', (done) => {
@@ -469,7 +418,7 @@ describe('Consul', () => {
 
     consul.initialize();
     consul.mock.emitChange('catalog-service', {elasticsearch: ['production']});
-    consul.mock.emitChange('elasticsearch-production', []);
+    consul.mock.emitChange('elasticsearch', []);
   });
 
   it('can clear its properties', (done) => {
@@ -483,7 +432,7 @@ describe('Consul', () => {
 
     consul.initialize();
     consul.mock.emitChange('catalog-service', {elasticsearch: ['production']});
-    consul.mock.emitChange('elasticsearch-production', []);
+    consul.mock.emitChange('elasticsearch', []);
   });
 });
 


### PR DESCRIPTION
Per #103, we are removing tag parsing from the Consul source completely. Later versions will likely support a `key:value` format in tags. This PR resolves #103.