### PR TITLE
Fix: Travis test timeout latency

### DIFF
--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -21,6 +21,7 @@ const fakeIndexResponse = {
 
 /* eslint-disable func-names, max-nested-callbacks */
 describe('Plugin manager', function () {
+  this.timeout(5000); // eslint-disable-line rapid7/static-magic-numbers
   const unknownEndpointErr = new Error('UnknownEndpoint');
   const _S3 = AWS.S3;
   let manager,


### PR DESCRIPTION
Travis introduces enough lag in test execution time that at least one of our tests is failing because it times out and a few others are getting close to the timeout duration. This PR bumps that to 5 seconds to give us a bit of a buffer.