### PR TITLE
Feature: Configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,107 +27,12 @@ The Propsd server runs under [Node.js][]. Run the following command to start it.
 node bin/server.js
 ~~~
 
-This will start the [HTTP server][http-api] listening on port 127.0.0.1:9100. If
-you need to specify different server options, see the configuration section
-below. Inline help is available with the `--help` argument.
+This will start the [HTTP server][http-api] listening on port 127.0.0.1:9100.
+If you need to specify different server options, see the [getting started
+guide][gsg]. Inline help is available with the `--help` argument.
 
 ~~~bash
 node bin/server.js --help
-~~~
-
-## Configuration
-
-Propsd reads its configuration from a JSON file. The `--config-file` argument
-can be provided to specify where to read the configuration file from. The
-following configuration options are supported.
-
-### service:hostname
-
-This defines the address the propsd server will listen on. By default it's
-127.0.0.1.
-
-### service:port
-
-This defines the port the propsd server will listen on. By default it's 9100.
-
-### log:level
-
-This defines the verbosity of logging. The default level is "info". Other
-supported values are "debug", "verbose", "warn", and "error".
-
-### log:access
-
-Propsd also logs access requests to its endpoints. The `log:access` configuration namespace exposes one option: `level`.
-
-Output is logged in JSON format using the standard [Apache combined log format](https://httpd.apache.org/docs/2.4/logs.html#combined).
-
-### log:access:level
-This defines the verbosity of access logging. The default level is "verbose". Other supported values are "debug", "info", "warn", and "error".
-
-### properties
-
-The `properties` object can contain any arbitrary properties you want loaded into the `Metadata#properties` object when it's being used to interpolate sources from the index.
-
-For example, a config file with the following `properties` object:
-
-~~~json
-{
-	...
-	"properties": {
-		"foo": "bar",
-		"baz": "s3"
-	}
-	...
-}
-~~~
-
-When presented with the following index document:
-
-~~~json
-{
-	"version": 1.0,
-	"sources": [
-		{
-			"name": "foo",
-			"type": "{{ baz }}",
-			"parameters": {
-				"path": "{{ foo }}.json"
-			}
-		}
-	]
-}
-~~~
-
-Will yield this source:
-
-~~~json
-{
-	"name": "foo",
-	"type": "s3",
-	"parameters": {
-		"path": "bar.json"
-	}
-}
-~~~
-
-
-### Example
-
-An example configuration file is shown below. The server's address is set to
-10.0.0.0 and the port is set to 2600. The log level is set to warning and
-file logging is enabled.
-
-~~~json
-{
-  "service": {
-    "hostname": "10.0.0.0",
-    "port": 2600
-  },
-  "log": {
-    "level": "warn",
-    "filename": "/var/log/propsd.log"
-  }
-}
 ~~~
 
 ### Development

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -3,6 +3,11 @@
 * [Installation][]
   * Installing from pre-built packages
   * Installing from source
+* [Configuration][]
+  * Available command-line options
+  * Using configuration files
+  * Working with interpolated properties
 
 
 [Installation]: ./installation.md
+[Configuration]: ./configuration.md

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -148,6 +148,3 @@ Interpolated properties in templated documents are enclosed in double curly
 braces: `{{` and `}}`. The value betwen the double curly braces is a key from
 the `properties` object. Nested keys within the `properties` object are
 accessed by separating the keys with colons.
-
-
-[apache]: https://httpd.apache.org/docs/2.4/logs.html#combined

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -63,8 +63,9 @@ The configuration file below is the default settings for propsd.
 
 * `log` - These settings control logging.
 
-  Propsd treats logging as an event stream and logs to `stdout`. If you
-  need routing or storage of logs, you'll want to handle that outside propsd.
+  Propsd treats logging as an event stream and logs to `stdout`. Logged events
+  are formatted as JSON objects separated by newlines. If you need routing or
+  storage of logs, you'll want to handle that outside propsd.
 
   The following keys are available:
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,34 @@
+# How to configure propsd #
+
+Configuration options for propsd can be specified by providing a configuration
+file on the command-line.
+
+## Command-line Options ##
+
+The options below are specified on the command-line.
+
+* `--config` - A configuration file to load. For more information on the format
+  of this file, see the **Configuration Files** section. Only one configuration
+  file can be specified. Multiple uses of this argument will result in only the
+  last configuration file being read.
+
+## Configuration Files ##
+
+Configuration files are JSON formatted. They are a single JSON object
+containing configuration values.
+
+### Example Configuration File ###
+~~~json
+{
+  "service": {
+    "hostname": "127.0.0.1",
+    "port": 9100
+  }
+}
+~~~
+
+### Configuration Key Reference ###
+
+* `service` - This object allows setting options to control the HTTP API.
+  * `hostname` - The address the HTTP API binds to. Defaults to "127.0.0.1".
+  * `port` - The port the HTTP API listens on. Defaults to 9100.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -41,10 +41,7 @@ The configuration file below is the default settings for propsd.
     "port": 9100
   },
   "log": {
-    "level": "info",
-    "access": {
-      "level": "verbose"
-    }
+    "level": "info"
   },
   "index": {
     "path": "index.json",
@@ -75,18 +72,6 @@ The configuration file below is the default settings for propsd.
     "warn", and "error". Each log level encompases all the ones below it. So
     "debug" is the most verbose and "error" is the least verbose. Defaults to
     "info".
-
-  * `access` - These settings control access logging.
-
-  Propsd logs access requests to its end points. Access requests are logged in
-  JSON format using the [Apache combined log format][apache].
-
-  The following keys are available:
-
-    * `level` - The level to log access requests at. Valid values are "debug",
-      "verbose", "info", "warn", and "error". Setting this to a level that's
-      equal to or lower than the `log:level` makes access logs visible. Defaults
-      to "verbose".
 
 * `index` - These settings control the first file properties are read from.
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -118,7 +118,7 @@ The configuration file below is the default settings for propsd.
 ## Interpolated Properties ##
 
 Propsd supports injecting static values defined in configuration files into the
-property documents read from S3. This provides way to read instance specific
+property documents read from S3. This provides a way to read instance specific
 properties.
 
 Suppose you have two configurations for metrics polling, fast and slow. Fast
@@ -155,7 +155,7 @@ configuration to read the "fast" document looks like this.
 }
 ~~~
 
-If the `properties:speed` key was configured as"slow", the `metrics/slow.json`
+If the `properties:speed` key was configured as "slow", the `metrics/slow.json`
 document would be read instead.
 
 Interpolated properties in templated documents are enclosed in double curly

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -17,7 +17,23 @@ The options below are specified on the command-line.
 Configuration files are JSON formatted. They are a single JSON object
 containing configuration values.
 
-### Example Configuration File ###
+### Minimal Configuration File ###
+
+The configuration file below is the minimal settings that must be specified in
+order for propsd to run.
+
+~~~json
+{
+  "index": {
+    "bucket": "propsd.corp.com"
+  }
+}
+~~~
+
+### Default Configuration File ###
+
+The configuration file below is the default settings for propsd.
+
 ~~~json
 {
   "service": {
@@ -29,6 +45,11 @@ containing configuration values.
     "access": {
       "level": "verbose"
     }
+  },
+  "index": {
+    "path": "index.json",
+    "interval": 30000,
+    "region": "us-east-1"
   }
 }
 ~~~
@@ -66,6 +87,26 @@ containing configuration values.
       "verbose", "info", "warn", and "error". Setting this to a level that's
       equal to or lower than the `log:level` makes access logs visible. Defaults
       to "verbose".
+
+* `index` - These settings control the first file properites are read from.
+
+  Propsd reads properties from files stored in Amazon S3. Property files are
+  JSON documents. A single property file must be configured as an index that
+  lists other property files to read. Property files are polled periodicaly for
+  changes. This allows new property files to be read at run time without
+  requiring a restart of propsd.
+
+  * `bucket` - The S3 bucket to read the index property file from. This has no
+    default value and must be explicitly configured.
+
+  * `region` - The AWS region where the S3 bucket is located. Defaults to
+    "us-east-1".
+
+  * `path` - The path in the S3 bucket to read as the index property file.
+    Defaults to "index.json".
+
+  * `interval` - The time in milliseconds to poll the index property file for
+    changes. Defaults to 30000 (30 seconds).
 
 
 [apache]: https://httpd.apache.org/docs/2.4/logs.html#combined

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -23,12 +23,49 @@ containing configuration values.
   "service": {
     "hostname": "127.0.0.1",
     "port": 9100
+  },
+  "log": {
+    "level": "info",
+    "access": {
+      "level": "verbose"
+    }
   }
 }
 ~~~
 
 ### Configuration Key Reference ###
 
-* `service` - This object allows setting options to control the HTTP API.
+* `service` - These settings control the HTTP API.
+
+  The following keys are available:
+
   * `hostname` - The address the HTTP API binds to. Defaults to "127.0.0.1".
+
   * `port` - The port the HTTP API listens on. Defaults to 9100.
+
+* `log` - These settings control logging.
+
+  Propsd treats logging as an event stream and logs to `stdout`. If you
+  need routing or storage of logs, you'll want to handle that outside propsd.
+
+  The following keys are available:
+
+  * `level` - The level to log at. Valid values are "debug", "verbose", "info",
+    "warn", and "error". Each log level encompases all the ones below it. So
+    "debug" is the most verbose and "error" is the least verbose. Defaults to
+    "info".
+
+  * `access` - These settings control access logging.
+
+  Propsd logs access requests to its end points. Access requests are logged in
+  JSON format using the [Apache combined log format][apache].
+
+  The following keys are available:
+
+    * `level` - The level to log access requests at. Valid values are "debug",
+      "verbose", "info", "warn", and "error". Setting this to a level that's
+      equal to or lower than the `log:level` makes access logs visible. Defaults
+      to "verbose".
+
+
+[apache]: https://httpd.apache.org/docs/2.4/logs.html#combined


### PR DESCRIPTION
This fixes #116 . There's now a configuration guide for propsd in the "docs/getting-started" folder. The README has been updated to remove the **Configuration** section and link to the guide instead.

Currently the guide only covers installation and configuration. There are addition issues filed to cover the remaining bits like usage (see #102 for the complete scope of this project).
