### PR TITLE
Bug: Deleted config file doesn't trigger S3 source shutdown

### DIFF
--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -228,7 +228,6 @@ class S3 extends EventEmitter {
           return callback(null, false);
         }
         if (err.code === 'NoSuchKey') {
-          this.shutdown();
           return callback(null, {properties: {}});
         }
 

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -228,7 +228,7 @@ class S3 extends EventEmitter {
           return callback(null, false);
         }
         if (err.code === 'NoSuchKey') {
-          return callback(null, {properties: {}});
+          return callback(null, new Buffer(JSON.stringify({properties: {}})));
         }
 
         return callback(err);

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -228,7 +228,8 @@ class S3 extends EventEmitter {
           return callback(null, false);
         }
         if (err.code === 'NoSuchKey') {
-          return callback(null, false);
+          this.shutdown();
+          return callback(null, {properties: {}});
         }
 
         return callback(err);

--- a/test/s3.js
+++ b/test/s3.js
@@ -105,17 +105,13 @@ describe('S3 source plugin', () => {
   }));
 
   it('clears cached properties if getRequest returns a NoSuchKey error', (done) => {
-    S3 = s3Stub({
-      getObject: sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null)
-    });
-
+    S3 = s3Stub({getObject: sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null)});
     s3WithNoSuchKeyError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
-    s3WithNoSuchKeyError.on('shutdown', () => {
+    s3WithNoSuchKeyError.once('update', () => {
       s3WithNoSuchKeyError.properties.should.be.empty();
       done();
     });
 
-    s3WithNoSuchKeyError.initialize();
     s3WithNoSuchKeyError.properties = {foo: 'bar'};
   });
 
@@ -125,6 +121,7 @@ describe('S3 source plugin', () => {
     });
 
     s3WithNotModifiedError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
+    s3WithNoSuchKeyError.initialize();
   });
 
   it('doesn\'t do anything if getRequest returns a NotModified error', (done) => {

--- a/test/s3.js
+++ b/test/s3.js
@@ -112,21 +112,41 @@ describe('S3 source plugin', () => {
     s3WithNoSuchKeyError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
   });
 
-  it('doesn\'t do anything if getRequest returns a NoSuchKey error', (done) => {
+  it('shuts down the source if getRequest returns a NoSuchKey error', (done) => {
     const errorSpy = sinon.spy();
     const updateSpy = sinon.spy();
 
+    shutdownSpy = sinon.spy();
+
     s3WithNoSuchKeyError.on('error', errorSpy);
     s3WithNoSuchKeyError.on('update', updateSpy);
+    s3WithNoSuchKeyError.on('shutdown', shutdownSpy);
 
     s3WithNoSuchKeyError.on('shutdown', () => {
       errorSpy.should.not.be.called();
       updateSpy.should.not.be.called();
+      shutdownSpy.should.be.called();
+      s3WithNoSuchKeyError.properties.should.be.empty();
       done();
     });
 
     s3WithNoSuchKeyError.initialize();
-    s3WithNoSuchKeyError.shutdown();
+    s3WithNoSuchKeyError.properties = {foo: 'bar'};
+  });
+
+  it('clears cached properties if getRequest returns a NoSuchKey error', (done) => {
+    S3 = s3Stub({
+      getObject: sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null)
+    });
+
+    s3WithNoSuchKeyError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
+    s3WithNoSuchKeyError.on('shutdown', () => {
+      s3WithNoSuchKeyError.properties.should.be.empty();
+      done();
+    });
+
+    s3WithNoSuchKeyError.initialize();
+    s3WithNoSuchKeyError.properties = {foo: 'bar'};
   });
 
   before(() => {

--- a/test/s3.js
+++ b/test/s3.js
@@ -104,36 +104,6 @@ describe('S3 source plugin', () => {
     this.s3.initialize();
   }));
 
-  before(() => {
-    S3 = s3Stub({
-      getObject: sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null)
-    });
-
-    s3WithNoSuchKeyError = new S3({bucket: DEFAULT_BUCKET, path: 'foo.json'});
-  });
-
-  it('shuts down the source if getRequest returns a NoSuchKey error', (done) => {
-    const errorSpy = sinon.spy();
-    const updateSpy = sinon.spy();
-
-    shutdownSpy = sinon.spy();
-
-    s3WithNoSuchKeyError.on('error', errorSpy);
-    s3WithNoSuchKeyError.on('update', updateSpy);
-    s3WithNoSuchKeyError.on('shutdown', shutdownSpy);
-
-    s3WithNoSuchKeyError.on('shutdown', () => {
-      errorSpy.should.not.be.called();
-      updateSpy.should.not.be.called();
-      shutdownSpy.should.be.called();
-      s3WithNoSuchKeyError.properties.should.be.empty();
-      done();
-    });
-
-    s3WithNoSuchKeyError.initialize();
-    s3WithNoSuchKeyError.properties = {foo: 'bar'};
-  });
-
   it('clears cached properties if getRequest returns a NoSuchKey error', (done) => {
     S3 = s3Stub({
       getObject: sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null)


### PR DESCRIPTION
This PR updates `_fetch()` to shut the source down and clear its properties if S3.getObject returns a NoSuchKey error. Resolves #123.