### PR TITLE
Feature: Get specific property

### DIFF
--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -110,6 +110,21 @@ function makeConquesoProperties(properties) {
  * @param {Storage} storage
  */
 function Conqueso(app, storage) {
+  // Conqueso compatible APIs are defined before the generic catch all route.
+  app.get('/v1/conqueso/api/roles/:role/properties/:property', (req, res) => {
+    const property = req.params.property;
+
+    res.set('Content-Type', 'text/plain');
+    res.status(HTTP_OK);
+
+    if (property && (property in storage.properties)) {
+      res.end(String(storage.properties[property]));
+    } else {
+      res.end();
+    }
+  });
+
+  // Handle any other requests by returning all properites.
   const route = app.route('/v1/conqueso*');
   const allowedMethods = 'GET,POST,PUT,OPTIONS';
 
@@ -120,19 +135,9 @@ function Conqueso(app, storage) {
   }
 
   route.get((req, res) => {
-    const prop = req.params['0'].replace(new RegExp('/', 'g'), '');
-    let val;
-
     res.set('Content-Type', 'text/plain');
     res.status(HTTP_OK);
-
-    if (prop && (prop in storage.properties)) {
-      val = String(storage.properties[prop]);
-    } else {
-      val = makeConquesoProperties(storage.properties);
-    }
-
-    res.end(val);
+    res.end(makeConquesoProperties(storage.properties));
   });
 
   // Express defaults to using the GET route for HEAD requests.

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -100,7 +100,7 @@ function makeConquesoProperties(properties) {
   results = translateConquesoAddresses(results);
   results = flatten(results);
 
-  return makeJavaProperties(results);
+  return results;
 }
 
 /**
@@ -113,12 +113,13 @@ function Conqueso(app, storage) {
   // Conqueso compatible APIs are defined before the generic catch all route.
   app.get('/v1/conqueso/api/roles/:role/properties/:property', (req, res) => {
     const property = req.params.property;
+    const properties = makeConquesoProperties(storage.properties);
 
     res.set('Content-Type', 'text/plain');
     res.status(HTTP_OK);
 
-    if (property && (property in storage.properties)) {
-      res.end(String(storage.properties[property]));
+    if (property && (properties.hasOwnProperty(property))) {
+      res.end(String(properties[property]));
     } else {
       res.end();
     }
@@ -137,7 +138,7 @@ function Conqueso(app, storage) {
   route.get((req, res) => {
     res.set('Content-Type', 'text/plain');
     res.status(HTTP_OK);
-    res.end(makeConquesoProperties(storage.properties));
+    res.end(makeJavaProperties(makeConquesoProperties(storage.properties)));
   });
 
   // Express defaults to using the GET route for HEAD requests.

--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -120,9 +120,19 @@ function Conqueso(app, storage) {
   }
 
   route.get((req, res) => {
+    const prop = req.params['0'].replace(new RegExp('/', 'g'), '');
+    let val;
+
     res.set('Content-Type', 'text/plain');
     res.status(HTTP_OK);
-    res.end(makeConquesoProperties(storage.properties));
+
+    if (prop && (prop in storage.properties)) {
+      val = String(storage.properties[prop]);
+    } else {
+      val = makeConquesoProperties(storage.properties);
+    }
+
+    res.end(val);
   });
 
   // Express defaults to using the GET route for HEAD requests.

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -147,13 +147,15 @@ describe('Conqueso API v1', () => {
       .expect('Content-Type', 'text/plain; charset=utf-8')
       .expect(HTTP_OK, nestedJavaProperties, done);
   });
+
   it('retrieves a specific property if it exists', (done) => {
     request(server)
-        .get('/v1/conqueso/name')
+        .get('/v1/conqueso/api/roles/global/properties/name')
         .set('Accept', 'text/plain')
         .expect('Content-Type', 'text/plain; charset=utf-8')
         .expect(HTTP_OK, 'hipster-mode-enabled', done);
   });
+
   after((done) => {
     server.close(done);
   });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -150,10 +150,18 @@ describe('Conqueso API v1', () => {
 
   it('retrieves a specific property if it exists', (done) => {
     request(server)
-        .get('/v1/conqueso/api/roles/global/properties/name')
-        .set('Accept', 'text/plain')
-        .expect('Content-Type', 'text/plain; charset=utf-8')
-        .expect(HTTP_OK, 'hipster-mode-enabled', done);
+      .get('/v1/conqueso/api/roles/global/properties/name')
+      .set('Accept', 'text/plain')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(HTTP_OK, 'hipster-mode-enabled', done);
+  });
+
+  it('returns no data if a specific property does not exist', (done) => {
+    request(server)
+      .get('/v1/conqueso/api/roles/global/properties/bogus')
+      .set('Accept', 'text/plain')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(HTTP_OK, '', done);
   });
 
   after((done) => {

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -147,6 +147,13 @@ describe('Conqueso API v1', () => {
       .expect('Content-Type', 'text/plain; charset=utf-8')
       .expect(HTTP_OK, nestedJavaProperties, done);
   });
+  it('retrieves a specific property if it exists', (done) => {
+    request(server)
+        .get('/v1/conqueso/name')
+        .set('Accept', 'text/plain')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(HTTP_OK, 'hipster-mode-enabled', done);
+  });
   after((done) => {
     server.close(done);
   });

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -150,15 +150,15 @@ describe('Conqueso API v1', () => {
 
   it('retrieves a specific property if it exists', (done) => {
     request(server)
-      .get('/v1/conqueso/api/roles/global/properties/name')
+      .get('/v1/conqueso/api/roles/global/properties/food.name')
       .set('Accept', 'text/plain')
       .expect('Content-Type', 'text/plain; charset=utf-8')
-      .expect(HTTP_OK, 'hipster-mode-enabled', done);
+      .expect(HTTP_OK, 'tacos', done);
   });
 
   it('returns no data if a specific property does not exist', (done) => {
     request(server)
-      .get('/v1/conqueso/api/roles/global/properties/bogus')
+      .get('/v1/conqueso/api/roles/global/properties/food.gluten')
       .set('Accept', 'text/plain')
       .expect('Content-Type', 'text/plain; charset=utf-8')
       .expect(HTTP_OK, '', done);


### PR DESCRIPTION
This PR resolves #136. It only retrieves first-level properties.

For example, `/v1/conqueso/foo.bar` will return the value at `storage.properties['foo.bar']` whereas `/v1/conqueso/foo/bar` will return the value at `storage.properties['foo']['bar']`.