### PR TITLE
Fix: Cache properites when index rebuilds

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -81,7 +81,6 @@ class Storage {
     while (i--) {
       this.unregister(this.sources[i]);
     }
-    this.properties = Object.create(null);
   }
 
   /**

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -228,7 +228,7 @@ describe('Storage Engine', () => {
 
     storage.clear();
     should(storage.sources.length).equal(0);
-    should(storage.properties).eql({});
+    should(storage.properties).eql({drink: ['coffee', 'hoppy IPA'], food: ['tacos', 'peanuts']});
   });
 
   it('shuts down plugins when unregistered', (done) => {

--- a/test/storage-engine.js
+++ b/test/storage-engine.js
@@ -211,8 +211,10 @@ describe('Storage Engine', () => {
     should(storage.sources.length).equal(2);
 
     storage.unregister(source2);
-    storage.update();
     should(storage.sources.length).equal(1);
+    should(storage.properties).eql({drink: ['coffee', 'hoppy IPA'], food: ['tacos', 'peanuts']});
+
+    storage.update();
     should(storage.properties).eql({food: ['tacos', 'peanuts']});
   });
 
@@ -229,6 +231,9 @@ describe('Storage Engine', () => {
     storage.clear();
     should(storage.sources.length).equal(0);
     should(storage.properties).eql({drink: ['coffee', 'hoppy IPA'], food: ['tacos', 'peanuts']});
+
+    storage.update();
+    should(storage.properties).eql({});
   });
 
   it('shuts down plugins when unregistered', (done) => {


### PR DESCRIPTION
This fixes #140. Properties are no longer cleared when sources are unregistered. Instead, we'll persist properties in memory. In memory properties will be updated when the underlying sources finish parsing and update.