### PR TITLE
Make `Source#initialize` return a Promise

### DIFF
--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -105,9 +105,6 @@ const Source = (Parser) => class extends EventEmitter {
       return this;
     }
 
-    this._ok = false;
-    this.signature = null;
-
     Log.info(`Stopping down ${this.type} source ${this.name} polling`, {
       source: this.name,
       type: this.type

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -1,0 +1,182 @@
+/* global Log, Config */
+'use strict';
+
+const EventEmitter = require('events').EventEmitter;
+const DEFAULT_INTERVAL = 60000;
+
+const Source = (Parser) => class extends EventEmitter {
+  constructor(options) {
+    super();
+
+    this._parser = new Parser(options);
+
+    this.type = options.type;
+    this.name = options.name || options.type;
+    this.namespace = options.namespace;
+    this.interval = Number(options.interval) || DEFAULT_INTERVAL;
+
+    this._ok = false;
+    this._updated = null;
+
+    this.properties = {};
+  }
+
+  /**
+   * Start a polling interval loop
+   *
+   * @return {Promise<Source>} Promise that resolves with this instance
+   *                           when the source has successfully fetched data
+   */
+  start() {
+    if (this._timer) {
+      return Promise.resolve(this);
+    }
+
+    this.emit('init');
+    this.emit('startup');
+    Log.info(`Starting ${this.type} source ${this.name} polling`, {
+      source: this.name,
+      type: this.type
+    });
+
+    // Resolve a promise on the first update event.
+    const promise = new Promise((resolve) => this.once('update', resolve));
+
+    // Initialize state to 'RUNNING'
+    this._timer = true;
+
+    /**
+     * Crete a polling loop around setTimeout. This allows the interval to be changed
+     * without stopping the loop], and also allows us to inject exit points where we
+     * want them for clean shutdown behavior.
+     */
+    setImmediate(function poll() {
+      const timer = Date.now();
+
+      Log.debug(`Polling source ${this.name} for updates`, {
+        source: this.name,
+        type: this.type
+      });
+
+      this._fetch((err, data) => {
+        // If `stop()` was called _during_ a fetch operation, `clearTimeout()`
+        // will have no effect. Instead, we overload `_interval` as a state to detect
+        // if a shutdown has been initiated. False-y -> don't set another timeout.
+        if (!this._running) {
+          return;
+        }
+
+        // Schedule the next execution
+        this._timer = setTimeout(poll.bind(this), this.interval);
+
+        if (err) {
+          return this._error(err); // eslint-disable-line consistent-return
+        }
+
+        Log.debug(`Polled source ${this.name} in ${(Date.now() - timer)}ms`, {
+          source: this.name,
+          type: this.type
+        });
+
+        if (data) {
+          return this._update(data); // eslint-disable-line consistent-return
+        }
+
+        this.emit('no-update');
+        Log.debug(`Source ${this.name} is up to date`, {
+          source: this.name,
+          type: this.type
+        });
+      });
+
+      // Start the polling loop
+    }.bind(this));
+
+    return promise;
+  }
+
+  /**
+   * Stop the polling interval loop
+   *
+   * @return {Source} Receiver
+   */
+  stop() {
+    if (!this._running) {
+      return this;
+    }
+
+    this._ok = false;
+    this.signature = null;
+
+    Log.info(`Stopping down ${this.type} source ${this.name} polling`, {
+      source: this.name,
+      type: this.type
+    });
+
+    clearTimeout(this._timer);
+    delete this._timer;
+
+    this.emit('shutdown');
+    return this;
+  }
+
+  /**
+   * Check the status of the polling interval loop
+   *
+   * @return {Boolean} True if the pooling loop is running
+   */
+  get _running() {
+    return !!this._timer;
+  }
+
+  /**
+   * Called by implementations to update source data
+   *
+   * @param {Buffer}  data  Updated data from an implementation-specific source
+   * @return {Source} Reference to Source instance
+   * @private
+   */
+  _update(data) {
+    this._parser.update(data);
+
+    this._updated = new Date();
+    this._ok = true;
+
+    this.properties = this._parser.properties;
+
+    Log.info(`Updated source ${this.name}`, {
+      source: this.name,
+      type: this.type
+    });
+    this.emit('update', this);
+
+    return this;
+  }
+
+  /**
+   * Handle errors from underlying source facilities
+   *
+   * @emits {Error} error If any listeners have been registered
+   *
+   * @param  {Error} err An instance of Error
+   * @return {Metadata} Reference to instance
+   * @private
+   */
+  _error(err) {
+    this._ok = false;
+
+    Log.error(err, {
+      source: this.name,
+      type: this.type
+    });
+
+    // Only emit an error event if there are listeners.
+    if (this.listeners('error').length > 0) {
+      this.emit('error', err);
+    }
+
+    return this;
+  }
+};
+
+module.exports = Source;

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -4,6 +4,8 @@
 const EventEmitter = require('events').EventEmitter;
 const DEFAULT_INTERVAL = 60000;
 
+const deepDiff = require('deep-diff').diff;
+
 const Source = (Parser) => class extends EventEmitter {
   constructor(options) {
     super();
@@ -32,8 +34,6 @@ const Source = (Parser) => class extends EventEmitter {
       return Promise.resolve(this);
     }
 
-    this.emit('init');
-    this.emit('startup');
     Log.info(`Starting ${this.type} source ${this.name} polling`, {
       source: this.name,
       type: this.type
@@ -105,7 +105,7 @@ const Source = (Parser) => class extends EventEmitter {
       return this;
     }
 
-    Log.info(`Stopping down ${this.type} source ${this.name} polling`, {
+    Log.info(`Stopping ${this.type} source ${this.name} polling`, {
       source: this.name,
       type: this.type
     });
@@ -113,7 +113,6 @@ const Source = (Parser) => class extends EventEmitter {
     clearTimeout(this._timer);
     delete this._timer;
 
-    this.emit('shutdown');
     return this;
   }
 
@@ -136,16 +135,22 @@ const Source = (Parser) => class extends EventEmitter {
   _update(data) {
     this._parser.update(data);
 
+    // Logging to determine the extent of the update
+    const diff = deepDiff(this.properties, this._parser.properties);
+
+    if (diff) {
+      Log.verbose(`Calculated ${this.name} properties diff during update`, {diff});
+    }
+
     this._updated = new Date();
     this._ok = true;
 
     this.properties = this._parser.properties;
 
-    Log.info(`Updated source ${this.name}`, {
+    this.emit('update', this, {
       source: this.name,
       type: this.type
     });
-    this.emit('update', this);
 
     return this;
   }

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -77,7 +77,10 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
    */
   shutdown() {
     this.stop();
-    delete this.signature;
+
+    this._ok = false;
+    this.signature = null;
+
     return this;
   }
 

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -1,17 +1,15 @@
 /* global Log, Config */
-
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
 const Crypto = require('crypto');
 const Path = require('path');
 const Aws = require('aws-sdk');
 const deepDiff = require('deep-diff').diff;
 
-const DEFAULT_INTERVAL = 60000;
 const METADATA_LIST = /^(\d+)=(.+)$/;
 const METADATA_TIMEOUT = 500;
 
+const Source = require('./common');
 const Parser = require('./metadata/parser');
 const Util = require('./metadata/util');
 
@@ -27,49 +25,27 @@ const Util = require('./metadata/util');
  * @param {Object} options
  *      - {Number} interval Polling interval. Default 30s.
  */
-class Metadata extends EventEmitter {
+class Metadata extends Source(Parser) { // eslint-disable-line new-cap
   constructor(opts) {
-    super();
-    const options = opts || {};
+    // Inject defaults into options
+    const options = Object.assign({
+      type: 'ec2-metadata',
+      namespace: 'instance'
+    }, opts);
 
-    if (!options.hasOwnProperty('name')) {
-      options.name = 'ec2-metadata';
-    }
-    if (!options.hasOwnProperty('namespace')) {
-      options.namespace = 'instance';
-    }
-
-    this.interval = DEFAULT_INTERVAL;
-    this.type = 'ec2-metadata';
-    this._parser = new Parser(options);
-    this.name = options.name || 'source';
-    this._ok = false;
-    this._updated = null;
-    this.properties = {};
+    super(options);
 
     /**
      * Initialize the metadata-service client
      */
-    const host = options.host || Config.get('metadata:host');
-
     this.service = new Aws.MetadataService({
       httpOptions: {
         timeout: METADATA_TIMEOUT
       },
-      host
+      host: options.host || Config.get('metadata:host')
     });
 
-    this.configure(options);
     this.signature = null;
-  }
-
-  /**
-   * Check the status of the polling interval loop
-   *
-   * @return {Boolean} True if the pooling loop is running
-   */
-  get _running() {
-    return !!this._timer;
   }
 
   /**
@@ -86,89 +62,22 @@ class Metadata extends EventEmitter {
   }
 
   /**
-   * @param {Object} params
-   * @returns {Boolean}
-   */
-  configure(params) {
-    return Metadata.setIfChanged(this, 'interval', params.interval || DEFAULT_INTERVAL) || false;
-  }
-
-  /**
-   * Start the polling interval loop
+   * For Metadata, start a polling loop
    *
-   * @return {Metadata} Reference to instance
+   * @return {Promise<Metadata>} Resolves when the source has been initialized
    */
   initialize() {
-    if (this._timer) {
-      return this;
-    }
-
-    this.emit('init');
-
-    // Initialize state to 'RUNNING'
-    this._timer = true;
-    const _this = this;
-
-    this.emit('startup');
-
-    (function poll() {
-      const timer = Date.now();
-
-      Log.debug(`Polling source ${_this.name} for updates`, {
-        source: _this.name,
-        type: _this.type
-      });
-
-      _this._fetch((err, data) => {
-        // If `shutdown()` was called _during_ a fetch operation, `clearTimeout()`
-        // will have no effect. Instead, we overload `_interval` as a state to detect
-        // if a shutdown has been initiated. False-y -> don't set another timeout.
-        if (_this._running) {
-          _this._timer = setTimeout(poll, _this.interval);
-        }
-        if (err) {
-          return _this._error(err);
-        }
-
-        Log.debug(`Polled source ${_this.name} in ${(Date.now() - timer)}ms`, {
-          source: _this.name,
-          type: _this.type
-        });
-
-        if (data) {
-          return _this._update(data);
-        }
-        _this.emit('no-update');
-
-        Log.debug(`Source ${_this.name} is up to date`, {
-          source: _this.name,
-          type: _this.type
-        });
-      });
-
-      // Start the polling loop
-    }());
-
-    return this;
+    return this.start();
   }
 
   /**
-   * Stop the polling interval loop
+   * Stop the polling loop
    *
-   * @return {Metadata} Receiver
+   * @returns {Metadata} Metadata instance
    */
   shutdown() {
-    if (!this._running) {
-      return this;
-    }
-
-    this._ok = false;
-    this.signature = null;
-
-    clearTimeout(this._timer);
-    delete this._timer;
-
-    this.emit('shutdown');
+    this.stop();
+    delete this.signature;
     return this;
   }
 
@@ -184,13 +93,6 @@ class Metadata extends EventEmitter {
       interval: this.interval,
       running: this._running
     };
-  }
-
-  /**
-   * Clear the underlying properties object
-   */
-  clear() {
-    this.properties = {};
   }
 
   /**
@@ -240,61 +142,8 @@ class Metadata extends EventEmitter {
   }
 
   /**
-   * Called by implementations to update source data
    *
-   * @param {Buffer}  data  Updated data from an implementation-specific source
-   * @return {Metadata} Reference to instance
-   * @private
-   */
-  _update(data) {
-    this._parser.update(data);
-
-    // Logging to determine the extent of the update
-    const diff = deepDiff(this.properties, this._parser.properties);
-
-    if (diff) {
-      Log.verbose(`Calculated ${this.name} properties diff during update`, {diff});
-    }
-
-    this.properties = this._parser.properties;
-    this._updated = new Date();
-    this._ok = true;
-
-    this.emit('update', this, {
-      source: this.name,
-      type: this.type
-    });
-
-    return this;
-  }
-
-  /**
-   * Handle errors from underlying source facilities
-   *
-   * @emits {Error} error If any listeners have been registered
-   *
-   * @param  {Error} err An instance of Error
-   * @return {Metadata} Reference to instance
-   * @private
-   */
-  _error(err) {
-    this._ok = false;
-
-    // Only emit an error event if there are listeners.
-    if (this.listeners('error').length > 0) {
-      this.emit('error', err);
-    } else {
-      Log.error(err, {
-        source: this.name,
-        type: this.type
-      });
-    }
-
-    return this;
-  }
-
-  /**
-   *
+   * Fetch implementation for EC2 Metadata
    * @param {Function} callback
    * @private
    */
@@ -322,24 +171,6 @@ class Metadata extends EventEmitter {
       this.signature = signature;
       callback(null, data);
     });
-  }
-
-  /**
-   * Helper method to detect parameter changes
-   *
-   * @param {Object}  scope The target object on which to set a parameter
-   * @param {String}  key   The property of `scope` to set
-   * @param {*}   value The value to compare and set
-   * @return {Boolean} True if the parameter has been updated
-   * @static
-   */
-  static setIfChanged(scope, key, value) {
-    if (scope[key] === value) {
-      return false;
-    }
-
-    scope[key] = value; // eslint-disable-line no-param-reassign
-    return true;
   }
 }
 

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -67,6 +67,9 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
    * @return {Promise<Metadata>} Resolves when the source has been initialized
    */
   initialize() {
+    this.emit('init');
+    his.emit('startup');
+
     return this.start();
   }
 
@@ -80,6 +83,8 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
 
     this._ok = false;
     this.signature = null;
+
+    this.emit('shutdown');
 
     return this;
   }

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -4,7 +4,6 @@
 const Crypto = require('crypto');
 const Path = require('path');
 const Aws = require('aws-sdk');
-const deepDiff = require('deep-diff').diff;
 
 const METADATA_LIST = /^(\d+)=(.+)$/;
 const METADATA_TIMEOUT = 500;
@@ -68,7 +67,7 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
    */
   initialize() {
     this.emit('init');
-    his.emit('startup');
+    this.emit('startup');
 
     return this.start();
   }

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -66,6 +66,10 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
    * @return {Promise<Metadata>} Resolves when the source has been initialized
    */
   initialize() {
+    if (this._running) {
+      return Promise.resolve(this);
+    }
+
     this.emit('init');
     this.emit('startup');
 
@@ -78,6 +82,10 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
    * @returns {Metadata} Metadata instance
    */
   shutdown() {
+    if (!this._running) {
+      return this;
+    }
+
     this.stop();
 
     this._ok = false;

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -68,9 +68,8 @@ describe('Metadata source plugin', () => {
     this.m.shutdown();
   });
 
-  it('can only be initialized once', () => {
-    this.m.initialize();
-    this.m.should.deepEqual(this.m.initialize());
+  it('initialize returns a promise', () => {
+    this.m.initialize().should.be.instanceOf(Promise);
   });
 
   it('clears the sha1 signature when it\'s shutdown', (done) => {
@@ -130,15 +129,5 @@ describe('Metadata source plugin', () => {
 
   after(() => {
     this.m.service.host = '127.0.0.1:8080';
-  });
-
-  it('can clear its properties', (done) => {
-    this.m.on('update', () => {
-      this.m.clear();
-      this.m.properties.should.eql({});
-      done();
-    });
-
-    this.m.initialize();
   });
 });

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -30,7 +30,7 @@ describe('Metadata source plugin', () => {
   });
 
   it('initializes a timer with the set interval', (done) => {
-    this.m.on('update', () => {
+    this.m.once('update', () => {
       this.m._timer.should.have.keys(['_called', '_idleNext', '_idlePrev', '_idleStart', '_idleTimeout',
         '_onTimeout', '_repeat']);
       done();
@@ -40,7 +40,7 @@ describe('Metadata source plugin', () => {
   });
 
   it('munges a set of paths to create a valid data object', (done) => {
-    this.m.on('update', () => {
+    this.m.once('update', () => {
       const instance = this.m.properties.instance;
       const fake = fakeMetadata.latest['meta-data'];
       const creds = JSON.parse(fake.iam['security-credentials']['fake-role-name']);
@@ -57,7 +57,7 @@ describe('Metadata source plugin', () => {
   });
 
   it('shuts down cleanly', (done) => {
-    this.m.on('shutdown', () => {
+    this.m.once('shutdown', () => {
       const status = this.m.status();
 
       status.running.should.be.false();
@@ -73,7 +73,7 @@ describe('Metadata source plugin', () => {
   });
 
   it('clears the sha1 signature when it\'s shutdown', (done) => {
-    this.m.on('shutdown', () => {
+    this.m.once('shutdown', () => {
       should(this.m.signature).be.null();
       done();
     });
@@ -87,7 +87,7 @@ describe('Metadata source plugin', () => {
         signature = null,
         secondExecution = false;
 
-    this.m.on('update', () => {
+    this.m.once('update', () => {
       instanceId = this.m.properties.instance['ami-id'];
       signature = this.m.signature;
 
@@ -98,7 +98,7 @@ describe('Metadata source plugin', () => {
       this.m.initialize();
     });
 
-    this.m.on('no-update', () => {
+    this.m.once('no-update', () => {
       if (secondExecution) {
         this.m.properties.instance['ami-id'].should.equal(instanceId);
         this.m.signature.should.equal(signature);
@@ -111,7 +111,7 @@ describe('Metadata source plugin', () => {
 
   it('exposes an error when one occurs but continues running', (done) => {
     this.m.service.host = '0.0.0.0';
-    this.m.on('error', (err) => {
+    this.m.once('error', (err) => {
       const status = this.m.status();
 
       err.code.should.equal('ECONNREFUSED');


### PR DESCRIPTION
This will simplify the definition of dependency chains in the manager module.

* Remove the `Metadata#clear` method. This operation souldn't be possible.
* Move more a lot of boilerplate from the Metadata module into a common base for Source classes