### PR TITLE
Fix: Better logic around source reloading

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -185,44 +185,73 @@ class PluginManager extends EventEmitter {
   }
 
   /**
+   * Factory function to create instances of source plugins
+   * @param {object} source
+   * @returns {Metadata|S3|Consul}
+   * @private
+   */
+  _sourceFactory(source) {
+    let instance;
+
+    switch (source.type.toLowerCase()) {
+      case 's3':
+
+        // TODO: Support for sources in other buckets
+        instance = new S3(Object.assign(source.parameters, {bucket: this.index.bucket}));
+        break;
+      case 'consul':
+        instance = new Consul({
+          host: Config.get('consul:host'),
+          port: Config.get('consul:port'),
+          secure: Config.get('consul:secure')
+        });
+        break;
+      default:
+        this._error(new Error(`Source type ${source.type} not implemented`));
+    }
+
+    if (instance) {
+      return instance;
+    }
+  }
+
+  /**
    * Register the sources with the storage layer and their event handlers
    * @param {Array} sources
    * @private
    */
   _registerSources(sources) {
-    this.storage.clear();
+    // Remove duplicate new sources as source names should be unique
+    const uniqueNewSourceInstances = Object.create(null);
+    const newSourceInstances = [];
 
-    sources.forEach((source) => {
-      let instance;
+    sources.map(this._sourceFactory.bind(this))
+        .filter((s) => !!s)
+        .forEach((s) => uniqueNewSourceInstances[s.name] = s);
 
-      switch (source.type.toLowerCase()) {
-        case 's3':
+    /* eslint-disable guard-for-in */
+    for (const k in uniqueNewSourceInstances) {
+      newSourceInstances.push(uniqueNewSourceInstances[k]);
+    }
 
-          // TODO: Support for sources in other buckets
-          instance = new S3(Object.assign(source.parameters, {bucket: this.index.bucket}));
-          break;
+    /* eslint-enable */
 
-        // case 'file':
-        //  //
-        //  break;
-        case 'consul':
-          const existingConsulSources = this.storage.sources.filter((el) => el.type === 'consul');
+    // Figure out which sources are new and add them
+    const existingSourceNames = this.storage.sources.map((s) => s.name);
 
-          if (existingConsulSources.length <= 0) {
-            instance = new Consul({
-              host: Config.get('consul:host'),
-              port: Config.get('consul:port'),
-              secure: Config.get('consul:secure')
-            });
-          }
-          break;
-        default:
-          this._error(new Error(`Source type ${source.type} not implemented`));
-      }
+    newSourceInstances.filter((s) => {
+      return existingSourceNames.indexOf(s.name) === -1;
+    }).forEach((source) => {
+      this._registerSource(source);
+    });
 
-      if (instance) {
-        this._registerSource(instance);
-      }
+    // Figure out what sources should be removed and remove them
+    const newSourceNames = Array.from(new Set(newSourceInstances.map((s) => s.name)));
+
+    this.storage.sources.filter((s) => {
+      return newSourceNames.indexOf(s.name) === -1;
+    }).forEach((source) => {
+      this.storage.unregister(source);
     });
   }
 

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -210,9 +210,7 @@ class PluginManager extends EventEmitter {
         this._error(new Error(`Source type ${source.type} not implemented`));
     }
 
-    if (instance) {
-      return instance;
-    }
+    return instance;
   }
 
   /**

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -275,10 +275,12 @@ describe('Plugin manager', function () {
     }
 
     manager.once('sources-registered', (storageSources) => {
-      storageSources[0].on('shutdown', () => {
+      storageSources.length.should.equal(1);
+      addS3Source('local');
+      manager.once('sources-registered', (s) => {
+        s.length.should.equal(2);
         done();
       });
-      addS3Source('local');
     });
 
     addS3Source('global');


### PR DESCRIPTION
This PR improves the way we handle source reloading. Instead of removing all sources and rebuilding the index, this adds sources if they aren't in `storage.sources` and are in the new index and removes them if they're in `storage.sources` but aren't in the new index.

This is a naive solution and can definitely be improved.