### PR TITLE
Fix: Keep index sources ordered

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -185,71 +185,44 @@ class PluginManager extends EventEmitter {
   }
 
   /**
-   * Factory function to create instances of source plugins
-   * @param {object} source
-   * @returns {Metadata|S3|Consul}
-   * @private
-   */
-  _sourceFactory(source) {
-    let instance;
-
-    switch (source.type.toLowerCase()) {
-      case 's3':
-
-        // TODO: Support for sources in other buckets
-        instance = new S3(Object.assign(source.parameters, {bucket: this.index.bucket}));
-        break;
-      case 'consul':
-        instance = new Consul({
-          host: Config.get('consul:host'),
-          port: Config.get('consul:port'),
-          secure: Config.get('consul:secure')
-        });
-        break;
-      default:
-        this._error(new Error(`Source type ${source.type} not implemented`));
-    }
-
-    return instance;
-  }
-
-  /**
    * Register the sources with the storage layer and their event handlers
    * @param {Array} sources
    * @private
    */
   _registerSources(sources) {
-    // Remove duplicate new sources as source names should be unique
-    const uniqueNewSourceInstances = Object.create(null);
-    const newSourceInstances = [];
+    this.storage.clear();
 
-    sources.map(this._sourceFactory.bind(this))
-        .filter((s) => !!s)
-        .forEach((s) => uniqueNewSourceInstances[s.name] = s);
+    sources.forEach((source) => {
+      let instance;
 
-    /* eslint-disable guard-for-in */
-    for (const k in uniqueNewSourceInstances) {
-      newSourceInstances.push(uniqueNewSourceInstances[k]);
-    }
+      switch (source.type.toLowerCase()) {
+        case 's3':
 
-    /* eslint-enable */
+          // TODO: Support for sources in other buckets
+          instance = new S3(Object.assign(source.parameters, {bucket: this.index.bucket}));
+          break;
 
-    // Figure out which sources are new and add them
-    const existingSourceNames = this.storage.sources.map((s) => s.name);
+        // case 'file':
+        //  //
+        //  break;
+        case 'consul':
+          const existingConsulSources = this.storage.sources.filter((el) => el.type === 'consul');
 
-    newSourceInstances.filter((s) => {
-      return existingSourceNames.indexOf(s.name) === -1;
-    }).forEach((source) => {
-      this._registerSource(source);
-    });
+          if (existingConsulSources.length <= 0) {
+            instance = new Consul({
+              host: Config.get('consul:host'),
+              port: Config.get('consul:port'),
+              secure: Config.get('consul:secure')
+            });
+          }
+          break;
+        default:
+          this._error(new Error(`Source type ${source.type} not implemented`));
+      }
 
-    // Figure out what sources should be removed and remove them
-    const newSourceNames = Array.from(new Set(newSourceInstances.map((s) => s.name)));
-
-    this.storage.sources.filter((s) => {
-      return newSourceNames.indexOf(s.name) === -1;
-    }).forEach((source) => {
-      this.storage.unregister(source);
+      if (instance) {
+        this._registerSource(instance);
+      }
     });
   }
 

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -275,12 +275,10 @@ describe('Plugin manager', function () {
     }
 
     manager.once('sources-registered', (storageSources) => {
-      storageSources.length.should.equal(1);
-      addS3Source('local');
-      manager.once('sources-registered', (s) => {
-        s.length.should.equal(2);
+      storageSources[0].on('shutdown', () => {
         done();
       });
+      addS3Source('local');
     });
 
     addS3Source('global');


### PR DESCRIPTION
This reverts the changes introduced by #146. We accidentally introduced a bug where the sources defined in the index could get out of order. A test has been added to ensure the sources in the index stay in the order they're defined.