### PR TITLE
Refactor Source to be a better defined state machine.

### DIFF
--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -91,7 +91,6 @@ const Source = (Parser) => class extends EventEmitter {
       Log.debug(`Polling source ${this.name} for updates`, {
         source: this.name, type: this.type});
 
-
       this._fetch((err, data) => {
         if (!this._timer) {
           // If `stop()` was called _during_ a fetch operation, `clearTimeout()`

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -10,63 +10,97 @@ const Source = (Parser) => class extends EventEmitter {
   constructor(options) {
     super();
 
-    this._parser = new Parser(options);
+    this._parser = options.parser || new Parser(options);
 
     this.type = options.type;
     this.name = options.name || options.type;
     this.namespace = options.namespace;
     this.interval = Number(options.interval) || DEFAULT_INTERVAL;
 
-    this._ok = false;
-    this._updated = null;
+    this.state = Source.CREATED;
 
+    this._updated = null;
     this.properties = {};
+  }
+
+  /**
+   * Initialize a source in state:CREATED
+   *
+   * @return {Promise<Source>} Promise that resolves with this instance
+   *                           when the source has successfully fetched data
+   */
+  initialize() {
+    if (this.state !== Source.CREATED) {
+      return Promise.resolve(this);
+    }
+
+    // Resolve a promise on the first update event.
+    const promise = new Promise((resolve) => this.once('update', resolve));
+
+    this.state = Source.INITIALIZING;
+
+    // TODO These events are not necessary
+    this.emit('init');
+    this.emit('startup');
+
+    this.start();
+
+    return promise;
+  }
+
+  /**
+   * Shutdown a running source
+   *
+   * @returns {Source}
+   */
+  shutdown() {
+    if (this.state === Source.SHUTDOWN) {
+      return this;
+    }
+
+    this.stop();
+
+    this.state = Source.SHUTDOWN;
+    this.emit('shutdown');
+
+    return this;
   }
 
   /**
    * Start a polling interval loop
    *
-   * @return {Promise<Source>} Promise that resolves with this instance
-   *                           when the source has successfully fetched data
+   * @returns {Source}
    */
   start() {
     if (this._timer) {
-      return Promise.resolve(this);
+      return this;
     }
+    this._timer = true;
 
     Log.info(`Starting ${this.type} source ${this.name} polling`, {
-      source: this.name,
-      type: this.type
-    });
-
-    // Resolve a promise on the first update event.
-    const promise = new Promise((resolve) => this.once('update', resolve));
-
-    // Initialize state to 'RUNNING'
-    this._timer = true;
+      source: this.name, type: this.type});
 
     /**
      * Crete a polling loop around setTimeout. This allows the interval to be changed
-     * without stopping the loop], and also allows us to inject exit points where we
+     * without stopping the loop, and also allows us to inject exit points where we
      * want them for clean shutdown behavior.
      */
     setImmediate(function poll() {
       const timer = Date.now();
 
       Log.debug(`Polling source ${this.name} for updates`, {
-        source: this.name,
-        type: this.type
-      });
+        source: this.name, type: this.type});
+
 
       this._fetch((err, data) => {
-        // If `stop()` was called _during_ a fetch operation, `clearTimeout()`
-        // will have no effect. Instead, we overload `_interval` as a state to detect
-        // if a shutdown has been initiated. False-y -> don't set another timeout.
-        if (!this._running) {
+        if (!this._timer) {
+          // If `stop()` was called _during_ a fetch operation, `clearTimeout()`
+          // will have no effect. Instead, we overload `_timer` as a state to detect
+          // if the loop should be stopped. False-y -> don't set another timeout.
           return;
         }
 
-        // Schedule the next execution
+        // Schedule the next execution, regardless of errors.
         this._timer = setTimeout(poll.bind(this), this.interval);
 
         if (err) {
@@ -74,41 +108,50 @@ const Source = (Parser) => class extends EventEmitter {
         }
 
         Log.debug(`Polled source ${this.name} in ${(Date.now() - timer)}ms`, {
-          source: this.name,
-          type: this.type
-        });
+          source: this.name, type: this.type});
 
-        if (data) {
-          return this._update(data); // eslint-disable-line consistent-return
+        // Not Modified
+        if (data === false) {
+          // TODO
+          this.emit('no-update');
+          Log.debug(`Source ${this.name} is up to date`, {
+            source: this.name, type: this.type});
+
+          return;
         }
 
-        this.emit('no-update');
-        Log.debug(`Source ${this.name} is up to date`, {
-          source: this.name,
-          type: this.type
-        });
-      });
+        // Does not exist
+        if (data === null) {
+          if (this.state !== Source.INITIALIZING) {
+            // If the source did exist, clear its properties and signal that it's changed.
+            this.properties = {};
+            this.state = Source.INITIALIZING;
+            this._updated = new Date();
 
-      // Start the polling loop
+            this.emit('update', this);
+            return;
+          }
+        }
+
+        this._update(data);
+      });
     }.bind(this));
 
-    return promise;
+    return this;
   }
 
   /**
    * Stop the polling interval loop
    *
-   * @return {Source} Receiver
+   * @return {Source}
    */
   stop() {
-    if (!this._running) {
+    if (!this._timer) {
       return this;
     }
 
     Log.info(`Stopping ${this.type} source ${this.name} polling`, {
-      source: this.name,
-      type: this.type
-    });
+      source: this.name, type: this.type});
 
     clearTimeout(this._timer);
     delete this._timer;
@@ -117,12 +160,24 @@ const Source = (Parser) => class extends EventEmitter {
   }
 
   /**
-   * Check the status of the polling interval loop
+   * Return an object describing the source-instance's current status
    *
-   * @return {Boolean} True if the pooling loop is running
+   * @return {Object}
    */
-  get _running() {
-    return !!this._timer;
+  status() {
+    return {
+      ok: this.ok,
+      state: this.state,
+      updated: this._updated,
+      interval: this.interval
+    };
+  }
+
+  /**
+   * OK States are anything but ERROR or WARNING
+   */
+  get ok() {
+    return this.state !== Source.ERROR && this.state !== Source.WARNING;
   }
 
   /**
@@ -133,7 +188,11 @@ const Source = (Parser) => class extends EventEmitter {
    * @private
    */
   _update(data) {
-    this._parser.update(data);
+    try {
+      this._parser.update(data);
+    } catch (e) {
+      return this._error(e);
+    }
 
     // Logging to determine the extent of the update
     const diff = deepDiff(this.properties, this._parser.properties);
@@ -142,16 +201,11 @@ const Source = (Parser) => class extends EventEmitter {
       Log.verbose(`Calculated ${this.name} properties diff during update`, {diff});
     }
 
-    this._updated = new Date();
-    this._ok = true;
-
     this.properties = this._parser.properties;
+    this.state = Source.RUNNING;
+    this._updated = new Date();
 
-    this.emit('update', this, {
-      source: this.name,
-      type: this.type
-    });
-
+    this.emit('update', this);
     return this;
   }
 
@@ -165,12 +219,9 @@ const Source = (Parser) => class extends EventEmitter {
    * @private
    */
   _error(err) {
-    this._ok = false;
+    this.state = Source.ERROR;
 
-    Log.error(err, {
-      source: this.name,
-      type: this.type
-    });
+    Log.error(err, {source: this.name, type: this.type});
 
     // Only emit an error event if there are listeners.
     if (this.listeners('error').length > 0) {
@@ -180,5 +231,15 @@ const Source = (Parser) => class extends EventEmitter {
     return this;
   }
 };
+
+// Lifecycle states
+Source.CREATED = 'CREATED';
+Source.INITIALIZING = 'INITIALIZING';
+Source.RUNNING = 'RUNNING';
+Source.SHUTDOWN = 'SHUTDOWN';
+
+// Error States
+Source.WARNING = 'WARNING';
+Source.ERROR = 'ERROR';
 
 module.exports = Source;

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -35,7 +35,7 @@ const Source = (Parser) => class extends EventEmitter {
     }
 
     // Resolve a promise on the first update event.
-    const promise = new Promise((resolve) => this.once('update', resolve));
+    const promise = new Promise((resolve) => this.once('initialized', resolve));
 
     this.state = Source.INITIALIZING;
 
@@ -109,29 +109,6 @@ const Source = (Parser) => class extends EventEmitter {
         Log.debug(`Polled source ${this.name} in ${(Date.now() - timer)}ms`, {
           source: this.name, type: this.type});
 
-        // Not Modified
-        if (data === false) {
-          // TODO
-          this.emit('no-update');
-          Log.debug(`Source ${this.name} is up to date`, {
-            source: this.name, type: this.type});
-
-          return;
-        }
-
-        // Does not exist
-        if (data === null) {
-          if (this.state !== Source.INITIALIZING) {
-            // If the source did exist, clear its properties and signal that it's changed.
-            this.properties = {};
-            this.state = Source.INITIALIZING;
-            this._updated = new Date();
-
-            this.emit('update', this);
-            return;
-          }
-        }
-
         this._update(data);
       });
     }.bind(this));
@@ -187,11 +164,65 @@ const Source = (Parser) => class extends EventEmitter {
    * @private
    */
   _update(data) {
+    // No changes to the source's data have occurred since the last update
+    if (data === Source.NO_UPDATE) {
+      Log.debug(`Source ${this.name} is up to date`, {
+        source: this.name, type: this.type});
+
+      // TODO Unnecessary event
+      this.emit('no-update');
+
+      return this;
+    }
+
+    // The source's underlying data resource does not exist
+    if (data === Source.NO_EXIST) {
+      switch (this.state) {
+        case Source.INITIALIZING:
+          this.state = Source.WAITING;
+
+          // Resolve the initialize promise
+          this.emit('initialized', this);
+          return this;
+
+        case Source.RUNNING:
+          this.state = Source.WAITING;
+
+          // Clear previous properties
+          this.properties = {};
+          this._updated = new Date();
+
+          // Notify watchers
+          this.emit('update', this);
+          return this;
+
+        case Source.WARNING:
+        case Source.ERROR:
+
+          // There was some kind of a successful response. Not an ERROR
+          // or WARNING anymore.
+          this.state = Source.WAITING;
+          return this;
+
+        default:
+          return this;
+      }
+    }
+
     try {
       this._parser.update(data);
     } catch (e) {
       return this._error(e);
     }
+
+    // Resolve the initialize promise
+    if (this.state === Source.INITIALIZING) {
+      this.emit('initialized', this);
+    }
+
+    // Successful update indicates a RUNNING state
+    this.state = Source.RUNNING;
+    this._updated = new Date();
 
     // Logging to determine the extent of the update
     const diff = deepDiff(this.properties, this._parser.properties);
@@ -201,8 +232,6 @@ const Source = (Parser) => class extends EventEmitter {
     }
 
     this.properties = this._parser.properties;
-    this.state = Source.RUNNING;
-    this._updated = new Date();
 
     this.emit('update', this);
     return this;
@@ -231,9 +260,14 @@ const Source = (Parser) => class extends EventEmitter {
   }
 };
 
+// Non-data responses from provider resources
+Source.NO_UPDATE = 'NO_UPDATE';
+Source.NO_EXIST = 'NO_EXIST';
+
 // Lifecycle states
 Source.CREATED = 'CREATED';
 Source.INITIALIZING = 'INITIALIZING';
+Source.WAITING = 'WAITING';
 Source.RUNNING = 'RUNNING';
 Source.SHUTDOWN = 'SHUTDOWN';
 

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -59,9 +59,24 @@ const Source = (Parser) => class extends EventEmitter {
       return this;
     }
 
-    this.stop();
+    const previousState = this.state;
 
+    this.stop();
+    this.properties = {};
     this.state = Source.SHUTDOWN;
+
+    /**
+     * Resolve the initialize promise.
+     *
+     * It's OK that the source is going to transition strait to shutdown. We've
+     * set its properties to an empty object, and it will never emit an update event.
+     * This means that it will never effect a parent view/property set, and should
+     * eventually get cleaned up.
+     */
+    if (previousState === Source.INITIALIZING) {
+      this.emit('initialized', this);
+    }
+
     this.emit('shutdown');
 
     return this;
@@ -216,14 +231,16 @@ const Source = (Parser) => class extends EventEmitter {
       return this._error(e);
     }
 
-    // Resolve the initialize promise
-    if (this.state === Source.INITIALIZING) {
-      this.emit('initialized', this);
-    }
+    const previousState = this.state;
 
     // Successful update indicates a RUNNING state
     this.state = Source.RUNNING;
     this._updated = new Date();
+
+    // Resolve the initialize promise
+    if (previousState === Source.INITIALIZING) {
+      this.emit('initialized', this);
+    }
 
     // Logging to determine the extent of the update
     const diff = deepDiff(this.properties, this._parser.properties);
@@ -248,9 +265,15 @@ const Source = (Parser) => class extends EventEmitter {
    * @private
    */
   _error(err) {
-    this.state = Source.ERROR;
+    const previousState = this.state;
 
+    this.state = Source.ERROR;
     Log.error(err, {source: this.name, type: this.type});
+
+    // Resolve the initialize promise
+    if (previousState === Source.INITIALIZING) {
+      this.emit('initialized', this);
+    }
 
     // Only emit an error event if there are listeners.
     if (this.listeners('error').length > 0) {

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -30,11 +30,12 @@ const Source = (Parser) => class extends EventEmitter {
    *                           when the source has successfully fetched data
    */
   initialize() {
+    // A source can only be initialized from the CREATED state
     if (this.state !== Source.CREATED) {
       return Promise.resolve(this);
     }
 
-    // Resolve a promise on the first update event.
+    // Resolve a promise when the source transitions out of the INITIALIZING state
     const promise = new Promise((resolve) => this.once('initialized', resolve));
 
     this.state = Source.INITIALIZING;

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -47,6 +47,13 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
     this.signature = null;
   }
 
+  shutdown() {
+    super.shutdown();
+    this.signature = null;
+
+    return this;
+  }
+
   /**
    * Metadata version
    *
@@ -58,56 +65,6 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
    */
   get _version() {
     return this.constructor.version;
-  }
-
-  /**
-   * For Metadata, start a polling loop
-   *
-   * @return {Promise<Metadata>} Resolves when the source has been initialized
-   */
-  initialize() {
-    if (this._running) {
-      return Promise.resolve(this);
-    }
-
-    this.emit('init');
-    this.emit('startup');
-
-    return this.start();
-  }
-
-  /**
-   * Stop the polling loop
-   *
-   * @returns {Metadata} Metadata instance
-   */
-  shutdown() {
-    if (!this._running) {
-      return this;
-    }
-
-    this.stop();
-
-    this._ok = false;
-    this.signature = null;
-
-    this.emit('shutdown');
-
-    return this;
-  }
-
-  /**
-   * Return an object describing the source-instance's current status
-   *
-   * @return {Object}
-   */
-  status() {
-    return {
-      ok: this._ok,
-      updated: this._updated,
-      interval: this.interval,
-      running: this._running
-    };
   }
 
   /**
@@ -126,7 +83,7 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
           return next(err);
         }
 
-        // This is a list! Split new-line delimited strings into an array and add to tail of paths
+        // This is a tree! Split new-line delimited strings into an array and add to tail of paths
         if (path.slice(-1) === '/') {
           const items = data.trim().split('\n');
 

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -137,7 +137,7 @@ class Metadata extends Source(Parser) { // eslint-disable-line new-cap
       const signature = hash.digest('base64');
 
       if (this.signature === signature) {
-        return callback(null, false);
+        return callback(null, Source.NO_UPDATE);
       }
 
       this.signature = signature;

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -71,11 +71,11 @@ class S3 extends Source(S3Parser) { // eslint-disable-line new-cap
     }, (err, data) => {
       if (err) {
         if (err.code === 'NotModified') {
-          return callback(null, false);
+          return callback(null, Source.NO_UPDATE);
         }
 
         if (err.code === 'NoSuchKey') {
-          return callback(null, null);
+          return callback(null, Source.NO_EXIST);
         }
 
         return callback(err);

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -1,11 +1,8 @@
 /* global Log, Config */
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
 const Aws = require('aws-sdk');
-const deepDiff = require('deep-diff').diff;
-
-const DEFAULT_INTERVAL = 60000;
+const Source = require('./common');
 
 class S3Parser {
   constructor() {
@@ -13,35 +10,30 @@ class S3Parser {
   }
 
   update(data) {
-    let properties = {};
-
-    try {
-      properties = JSON.parse(data.toString());
-    } catch (e) {
-      // We should have an error condition but tbd
-    }
-    this.properties = properties.properties;
+    this.properties = JSON.parse(data.toString()).properties;
   }
 }
 
-class S3 extends EventEmitter {
+class S3 extends Source(S3Parser) { // eslint-disable-line new-cap
   constructor(opts) {
-    super();
-    const options = opts || {};
+    // Inject defaults into options
+    const options = Object.assign({
+      type: 's3'
+    }, opts);
 
     if (!options.hasOwnProperty('bucket') || !options.hasOwnProperty('path')) {
       throw new Error('Bucket or path not supplied');
     }
 
     if (!options.hasOwnProperty('name')) {
-      this.name = `s3-${options.bucket}-${options.path}`;
+      options.name = `s3-${options.bucket}-${options.path}`;
     }
 
-    this.interval = DEFAULT_INTERVAL;
-    this.type = 's3';
-    this._parser = options.parser || new S3Parser(options);
-    this._ok = false;
-    this._updated = null;
+    super(options);
+
+    this.bucket = options.bucket || Config.get('index:bucket');
+    this.path = options.path;
+    this.etag = null;
 
     /**
      * Initialize the s3 client
@@ -55,151 +47,13 @@ class S3 extends EventEmitter {
     } else {
       config.region = Config.get('index:region');
     }
+
     this.service = new Aws.S3(config);
-
-    this.configure(options);
-    this.etag = null;
-    this.properties = {};
   }
 
-  /**
-   * Clear the underlying properties object
-   */
-  clear() {
-    this.properties = {};
-  }
-
-  /**
-   * Check the status of the polling interval loop
-   *
-   * @return {Boolean} True if the pooling loop is running
-   */
-  get _running() {
-    return !!this._timer;
-  }
-
-  /**
-   * @param {Object} params
-   * @returns {Boolean}
-   */
-  configure(params) {
-    let changed = false;
-
-    changed = S3.setIfChanged(this, 'bucket', params.bucket || Config.get('index:bucket')) || changed;
-    changed = S3.setIfChanged(this, 'interval', params.interval || DEFAULT_INTERVAL) || changed;
-    changed = S3.setIfChanged(this, 'path', params.path) || changed;
-
-    return changed;
-  }
-
-  initialize() {
-    if (this._timer) {
-      return this;
-    }
-
-    this.emit('init');
-
-    // Initialize state to 'RUNNING'
-    this._timer = true;
-    const _this = this;
-
-    this.emit('startup');
-
-    (function poll() {
-      const timer = Date.now();
-
-      Log.debug(`Polling source ${_this.name} for updates`, {
-        source: _this.name,
-        type: _this.type
-      });
-
-      _this._fetch((err, data) => {
-        // If `shutdown()` was called _during_ a fetch operation, `clearTimeout()`
-        // will have no effect. Instead, we overload `_interval` as a state to detect
-        // if a shutdown has been initiated. False-y -> don't set another timeout.
-        if (_this._running) {
-          _this._timer = setTimeout(poll, _this.interval);
-        }
-        if (err) {
-          return _this._error(err);
-        }
-
-        Log.debug(`Polled source ${_this.name} in ${(Date.now() - timer)}ms`, {
-          source: _this.name,
-          type: _this.type
-        });
-
-        if (data) {
-          return _this._update(data);
-        }
-        _this.emit('no-update');
-
-        Log.debug(`Source ${_this.name} is up to date`, {
-          source: _this.name,
-          type: _this.type
-        });
-      });
-
-      // Start the polling loop
-    }());
-
-    return this;
-  }
-
-  /**
-   * Stop the polling interval loop
-   *
-   * @return {S3} Receiver
-   */
   shutdown() {
-    if (!this._running) {
-      return this;
-    }
-
-    this._ok = false;
-
-    clearTimeout(this._timer);
-    delete this._timer;
-
-    this.emit('shutdown');
-    return this;
-  }
-
-  /**
-   * Return an object describing the source-instance's current status
-   *
-   * @return {Object}
-   */
-  status() {
-    return {
-      ok: this._ok,
-      updated: this._updated,
-      interval: this.interval,
-      running: this._running
-    };
-  }
-
-  /**
-   * Handle errors from underlying source facilities
-   *
-   * @emits {Error} error If any listeners have been registered
-   *
-   * @param  {Error} err An instance of Error
-   * @return {S3} Reference to instance
-   * @private
-   */
-  _error(err) {
-    this._ok = false;
-
-    // Only emit an error event if there are listeners.
-    if (this.listeners('error').length > 0) {
-      this.emit('error', err);
-    } else {
-      Log.error(err, {
-        source: this.name,
-        type: this.type
-      });
-    }
+    super.shutdown();
+    this.etag = null;
 
     return this;
   }
@@ -210,8 +64,6 @@ class S3 extends EventEmitter {
    * @private
    */
   _fetch(callback) {
-    const _this = this;
-
     this.service.getObject({
       Bucket: this.bucket,
       Key: this.path,
@@ -221,63 +73,17 @@ class S3 extends EventEmitter {
         if (err.code === 'NotModified') {
           return callback(null, false);
         }
+
         if (err.code === 'NoSuchKey') {
-          return callback(null, new Buffer(JSON.stringify({properties: {}})));
+          return callback(null, null);
         }
 
         return callback(err);
       }
 
-      _this.etag = data.ETag;
+      this.etag = data.ETag;
       callback(null, data.Body);
     });
-  }
-
-  /**
-   * Called by implementations to update source data
-   *
-   * @param {Buffer}  data  Updated data from an implementation-specific source
-   * @return {S3} Reference to instance
-   * @private
-   */
-  _update(data) {
-    this._parser.update(data);
-
-    // Logging to determine the extent of the update
-    const diff = deepDiff(this.properties, this._parser.properties);
-
-    if (diff) {
-      Log.verbose(`Calculated ${this.name} properties diff during update`, {diff});
-    }
-
-    this.properties = this._parser.properties;
-    this._updated = new Date();
-    this._ok = true;
-
-    this.emit('update', this, {
-      source: this.name,
-      type: this.type
-    });
-
-    return this;
-  }
-
-  /**
-   * Helper method to detect parameter changes
-   *
-   * @param {Object}  scope The target object on which to set a parameter
-   * @param {String}  key   The property of `scope` to set
-   * @param {*}   value The value to compare and set
-   * @return {Boolean} True if the parameter has been updated
-   * @static
-   */
-  static setIfChanged(scope, key, value) {
-    if (scope[key] === value) {
-      return false;
-    }
-
-    scope[key] = value; // eslint-disable-line no-param-reassign
-    return true;
   }
 }
 

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -7,6 +7,7 @@ const Path = require('path');
 const fs = require('fs');
 
 const Metadata = require('../lib/source/metadata');
+const Source = require('../lib/source/common');
 const fakeMetadata = JSON.parse(fs.readFileSync(Path.resolve(__dirname, './data/test-metadata.json')));
 
 const NON_DEFAULT_INTERVAL = 10000;
@@ -60,7 +61,7 @@ describe('Metadata source plugin', () => {
     this.m.once('shutdown', () => {
       const status = this.m.status();
 
-      status.running.should.be.false();
+      status.state.should.equal(Source.SHUTDOWN);
       done();
     });
 
@@ -92,10 +93,6 @@ describe('Metadata source plugin', () => {
       signature = this.m.signature;
 
       secondExecution = true;
-
-      // This is a terrible hack
-      this.m._timer = false;
-      this.m.initialize();
     });
 
     this.m.once('no-update', () => {
@@ -106,6 +103,7 @@ describe('Metadata source plugin', () => {
       }
     });
 
+    this.m.interval = 100;
     this.m.initialize();
   });
 
@@ -116,7 +114,7 @@ describe('Metadata source plugin', () => {
 
       err.code.should.equal('ECONNREFUSED');
       status.ok.should.be.false();
-      status.running.should.be.true();
+      status.state.should.equal(Source.ERROR);
       done();
     });
 

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -103,7 +103,7 @@ describe('Metadata source plugin', () => {
       }
     });
 
-    this.m.interval = 100;
+    this.m.interval = 100; // eslint-disable-line rapid7/static-magic-numbers
     this.m.initialize();
   });
 

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -9,6 +9,7 @@ const generateConsulStub = require('./utils/consul-stub');
 
 require('should-sinon');
 
+const Source = require('../lib/source/common');
 const PluginManager = require('../lib/plugin-manager');
 const StringTemplate = require('../lib/string-template');
 
@@ -171,7 +172,7 @@ describe('Plugin manager', function () {
         managerStatus.running.should.be.true();
         managerStatus.ok.should.be.false();
         metadataStatus.ok.should.be.false();
-        metadataStatus.running.should.be.true();
+        metadataStatus.state.should.equal(Source.ERROR);
 
         manager.metadata.service.host = '127.0.0.1:8080';
       }
@@ -206,7 +207,7 @@ describe('Plugin manager', function () {
         managerStatus.running.should.be.true();
         managerStatus.ok.should.be.false();
         indexStatus.ok.should.be.false();
-        indexStatus.running.should.be.true();
+        indexStatus.state.should.equal(Source.ERROR);
 
         AWS.S3.prototype.getObject = sinon.stub().callsArgWith(1, null, fakeIndexResponse);
       }


### PR DESCRIPTION
* Introduces a `#state` property and named states which consolidate previous `running` and `ok`
  registers.
* Introduces an additional return value for `#_fetch` to indicate that a source is `non-existent`,
  not just `not-updated`. If the source was RUNNING, this signal returns the source to INITIALIZING
  and notifies watchers accordingly.

Other Changes:

* Separate polling controls from initialize/shutdown
* Catch errors thrown from parsers
* Allow Sources' default Parsers to be overridden by `options.parser`