### PR TITLE
Metadata source should only poll once

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -96,6 +96,7 @@ class PluginManager extends EventEmitter {
     });
     this.metadata.on('error', (error) => {
       this._error(error);
+      this.metadata.once('update', () => this._loadSourcesFromIndex());
     });
 
     this._running = false;

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -97,9 +97,6 @@ class PluginManager extends EventEmitter {
     this.metadata.on('error', (error) => {
       this._error(error);
     });
-    this.metadata.on('update', () => {
-      this._loadSourcesFromIndex();
-    });
 
     this._running = false;
     this._ok = true;
@@ -111,8 +108,9 @@ class PluginManager extends EventEmitter {
   initialize() {
     Log.info('Initializing index and metadata');
     this._running = true;
-    this.index.initialize();
-    this.metadata.initialize();
+    this.metadata.initialize().then(() => {
+      this.index.initialize();
+    });
   }
 
   /**

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -90,8 +90,10 @@ class PluginManager extends EventEmitter {
       this._loadSourcesFromIndex();
     });
 
-    this.metadata = new Metadata();
-    this.metadata.service.host = configuration.metadataHost || Config.get('metadata:host');
+    this.metadata = new Metadata({
+      host: configuration.metadataHost || Config.get('metadata:host'),
+      interval: configuration.interval || Config.get('metadata:interval')
+    });
     this.metadata.on('error', (error) => {
       this._error(error);
     });

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -92,7 +92,7 @@ class PluginManager extends EventEmitter {
 
     this.metadata = new Metadata({
       host: configuration.metadataHost || Config.get('metadata:host'),
-      interval: configuration.interval || Config.get('metadata:interval')
+      interval: configuration.metadataInterval || Config.get('metadata:interval')
     });
     this.metadata.on('error', (error) => {
       this._error(error);

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -161,6 +161,28 @@ describe('Plugin manager', function () {
     manager.initialize();
   });
 
+  it('initializes the metadata before the index', function (done) {
+    const order = [];
+
+    function testInitializeOrder(source) {
+      order.push(source);
+      if (order.length >= 2) {
+        order.should.eql(['metadata', 'index']);
+        done();
+      }
+    }
+
+    manager.index.once('initialized', () => {
+      testInitializeOrder('index');
+    });
+
+    manager.metadata.once('initialized', () => {
+      testInitializeOrder('metadata');
+    });
+
+    manager.initialize();
+  });
+
   it('retries Metadata source until it succeeds if the Metadata source fails', function (done) {
     function onConnectionRefused(err) {
       if (err.code === 'ECONNREFUSED') {

--- a/test/plugin-manager.js
+++ b/test/plugin-manager.js
@@ -453,7 +453,7 @@ describe('Plugin manager', function () {
       baz: 'quiz'
     });
 
-    manager.metadata.once('update', () => {
+    manager.once('sources-generated', () => {
       manager.metadata.properties.should.have.ownProperty('foo');
       manager.metadata.properties.should.have.ownProperty('baz');
       done();


### PR DESCRIPTION
This is a quick fix to prevent hourly updates to the ec2 metadata service from triggering a full source rebuild. Once we've resolved that issue, we can reimplement the metadata source as a polling source.

Ref #147 