### PR TITLE
Fix: No colored logs

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -23,14 +23,6 @@ function Logger(level, filename) {
       VERBOSE: 3,
       DEBUG: 4,
       SILLY: 5
-    },
-    colors: {
-      ERROR: 'red',
-      WARN: 'yellow',
-      INFO: 'green',
-      VERBOSE: 'cyan',
-      DEBUG: 'blue',
-      SILLY: 'magenta'
     }
   };
 
@@ -41,15 +33,12 @@ function Logger(level, filename) {
     levels: javaLogLevels.levels,
     transports: [
       new Winston.transports.Console({
-        colorize: true,
         timestamp: true,
         json: true,
         stringify: true
       })
     ]
   });
-
-  Winston.addColors(javaLogLevels.colors);
 
   if (filename) {
     logger.add(Winston.transports.File, {filename, level});


### PR DESCRIPTION
This removes colors from logs. We're logging to STDOUT and letting users handle sending logs to terminals, files, syslog, whatever. Having colors on assumes the output is a color compatible terminal, which may not be the case.