### PR TITLE
Fix: Startable test servers

### DIFF
--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -55,10 +55,11 @@ class S3 extends Source(S3Parser) { // eslint-disable-line new-cap
 
   status() {
     const object = super.status();
+
     object.resource = `s3://${this.bucket}/${this.path}`;
     object.etag = JSON.parse(this._state);
 
-    return object
+    return object;
   }
 
   /**

--- a/test/bin/metadata-server.js
+++ b/test/bin/metadata-server.js
@@ -9,6 +9,6 @@ global.Config = require('nconf')
     .env()
     .file(Path.resolve(__dirname, '../data/config.json'))
     .defaults(require('../../config/defaults.json'));
-global.Log = require('../../lib/logger').attach(global.Config);
+global.Log = require('../../lib/logger').attach(Config.get('log:level'));
 
 server.start();

--- a/test/bin/s3-server.js
+++ b/test/bin/s3-server.js
@@ -10,7 +10,13 @@ const AWS = require('aws-sdk');
 const rmdir = require('rimraf');
 const walk = require('walk');
 const chokidar = require('chokidar');
-const nconf = require('nconf');
+
+global.Config = require('nconf')
+  .argv()
+  .env()
+  .file(Path.resolve(__dirname, '../data/config.json'))
+  .defaults(require('../../config/defaults.json'));
+global.Log = require('../../lib/logger').attach(Config.get('log:level'));
 
 const DEFAULT_HTTP_PORT = 4569;
 
@@ -40,9 +46,6 @@ const args = require('yargs')
 const hostname = args.h;
 const port = args.p;
 const path = Path.resolve(__dirname, `../../${args.d}`);
-
-nconf.set('log:level', 'debug');
-const Log = require('../../lib/logger').attach('debug');
 
 const awsConfig = {
   s3ForcePathStyle: true,


### PR DESCRIPTION
This allows the local test metadata and S3 servers to start. The S3 server now sets up the same configuration and logging as the metadata server.