### PR TITLE
Fix: Consul polling

### DIFF
--- a/lib/control/v1/conqueso.js
+++ b/lib/control/v1/conqueso.js
@@ -29,13 +29,7 @@ function makeJavaProperties(data) {
  *
  * Addresses returned by the Consul plugin are formatted as
  * {
- *   consul: {
- *     services: {
- *       <SERVICE>: {
- *         <INSTANCE>: <ADDRESS>
- *       }
- *     }
- *   }
+ *   "consul.service.addresses": ["x.x.x.x", "y.y.y.y"]
  * }
  *
  * Addresses returned by Conqueso are formatted as
@@ -43,19 +37,21 @@ function makeJavaProperties(data) {
  *   "conqueso.service.ips": "x.x.x.x, y.y.y.y"
  * }
  *
- * @param {Object} services    Properties as returned from Storage#properties.consul.services
+ * @param {Object} properties  Properties as returned from Storage#properties
  * @return {Object}            Properties with Consul address converted to Conqueso ones
  */
-function translateConquesoAddresses(services) {
-  const properties = {};
+function translateConquesoAddresses(properties) {
+  if (properties.consul) {
+    Object.keys(properties.consul).forEach((service) => {
+      const cluster = properties.consul[service].cluster;
 
-  Object.keys(services).forEach((service) => {
-    properties[`${service}.ips`] =
-      Object.keys(services[service])
-        .map((node) => services[service][node])
-        .join(',');
-  });
+  /* eslint-disable no-param-reassign */
+      properties[`conqueso.${cluster}.ips`] = properties.consul[service].addresses.join(',');
+    });
+    delete properties.consul;
+  }
 
+  /* eslint-enable no-param-reassign */
   return properties;
 }
 
@@ -66,17 +62,12 @@ function translateConquesoAddresses(services) {
  * @return {String}            Flattened Java properties as returned by Conqueso
  */
 function makeConquesoProperties(properties) {
-  const conquesoProperties = clone(properties);
+  let results = clone(properties);
 
-  // Replace consul properties with the old conqueso list format
-  if (properties.consul instanceof Object &&
-    properties.consul.services instanceof Object) {
-    conquesoProperties.conqueso =
-      translateConquesoAddresses(properties.consul.services);
-  }
-  delete conquesoProperties.consul;
+  results = translateConquesoAddresses(results);
+  results = flatten(results);
 
-  return flatten(conquesoProperties);
+  return results;
 }
 
 /**

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -6,7 +6,7 @@ const Source = require('./common');
 const Parser = require('./consul/parser');
 const each = require('./metadata/util').each;
 
-class Consul extends Source(Parser) { // eslint-disable-line new-cap
+class Consul extends Source.Polling(Parser) { // eslint-disable-line new-cap
   /**
    * Creates a new instance of a Consul Source
    *
@@ -26,62 +26,6 @@ class Consul extends Source(Parser) { // eslint-disable-line new-cap
       host: options.host,
       port: options.port,
       secure: !!options.secure
-    });
-  }
-
-  /**
-   * Start watching the Consul agent for changes
-   *
-   * @returns {Promise<Consul>}
-   */
-  initialize() {
-    const promise = super.initialize();
-
-    if (this.watcher) { return promise; }
-
-    this.watcher = this.client.watch({
-      method: this.client.health.state,
-      options: {state: 'any'}
-    });
-
-    this.watcher.on('error', (error) => {
-      this._error(error);
-    });
-
-    this.watcher.on('change', (checks) => {
-      this._update(checks);
-    });
-
-    return promise;
-  }
-
-  /**
-   * Stop watching the Consul agent for changes
-   *
-   * @returns {Consul}
-   */
-  shutdown() {
-    super.shutdown();
-
-    if (this.watcher) {
-      this.watcher.end();
-      delete this.watcher;
-    }
-
-    return this;
-  }
-
-  /**
-   * Update the catalog cache before parsing results
-   *
-   * @param  {Object} data Payload from watcher event
-   */
-  _update(data) {
-    this.client.catalog.node.list((err, nodes) => {
-      if (err) { return this._error(err); }
-
-      this.parser.catalog(nodes);
-      super._update(data);
     });
   }
 

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -57,22 +57,7 @@ class Consul extends Source.Polling(Parser) { // eslint-disable-line new-cap
             return next(error);
           }
 
-          const addresses = [];
-
-          data.forEach((info) => {
-            // Prefer the service address, not the Consul agent address.
-            if (info.Service && info.Service.Address) {
-              addresses.push(info.Service.Address);
-            } else if (info.Node && info.Node.Address) {
-              addresses.push(info.Node.Address);
-            }
-          });
-
-          properties[name] = {
-            cluster: name,
-            addresses: addresses
-          };
-
+          properties[name] = data;
           next();
         });
       };

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -99,7 +99,7 @@ class Consul extends Source(Parser) { // eslint-disable-line new-cap
         return callback(err);
       }
 
-      callback(null, Object.keys(result));
+      callback(null, Object.keys(result).sort());
     });
   }
 }

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -38,7 +38,7 @@ class Consul extends Source.Polling(Parser) { // eslint-disable-line new-cap
   _fetch(callback) {
     this.client.catalog.service.list({
       consistent: false,
-      state: true
+      stale: true
     }, (err, result) => {
       if (err) {
         return callback(err);
@@ -51,7 +51,7 @@ class Consul extends Source.Polling(Parser) { // eslint-disable-line new-cap
           service: name,
           passing: true,
           consistent: false,
-          state: true
+          stale: true
         }, (error, data) => {
           if (error) {
             return next(error);

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -4,6 +4,7 @@
 const Client = require('consul');
 const Source = require('./common');
 const Parser = require('./consul/parser');
+const each = require('./metadata/util').each;
 
 class Consul extends Source(Parser) { // eslint-disable-line new-cap
   /**
@@ -99,7 +100,44 @@ class Consul extends Source(Parser) { // eslint-disable-line new-cap
         return callback(err);
       }
 
-      callback(null, Object.keys(result).sort());
+      const properties = {};
+
+      const work = (name, next) => {
+        this.client.health.service({
+          service: name,
+          passing: true,
+          consistent: false,
+          state: true
+        }, (error, data) => {
+          if (error) {
+            return next(error);
+          }
+
+          const addresses = [];
+
+          data.forEach((info) => {
+            // Prefer the service address, not the Consul agent address.
+            if (info.Service && info.Service.Address) {
+              addresses.push(info.Service.Address);
+            } else if (info.Node && info.Node.Address) {
+              addresses.push(info.Node.Address);
+            }
+          });
+
+          properties[name] = {
+            cluster: name,
+            addresses: addresses
+          };
+
+          next();
+        });
+      };
+
+      const done = (error) => {
+        callback(error, properties);
+      };
+
+      each(Object.keys(result), work, done);
     });
   }
 }

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -83,6 +83,25 @@ class Consul extends Source(Parser) { // eslint-disable-line new-cap
       super._update(data);
     });
   }
+
+  /**
+   * Get a list services from the Consul catalog.
+   *
+   * @param {Function} callback  Function to call when finished
+   * @private
+   */
+  _fetch(callback) {
+    this.client.catalog.service.list({
+      consistent: false,
+      state: true
+    }, (err, result) => {
+      if (err) {
+        return callback(err);
+      }
+
+      callback(null, Object.keys(result));
+    });
+  }
 }
 
 Consul.DEFAULT_ADDRESS = '127.0.0.1';

--- a/lib/source/consul/parser.js
+++ b/lib/source/consul/parser.js
@@ -4,139 +4,37 @@
 class Parser {
   constructor() {
     this.properties = {};
-    this.nodes = {};
+    this.sources = {};
   }
 
   /**
-   * Parse data from the Consul health watcher
+   * Parse data from the Consul source. Keys in the data are names of services
+   * in Consul. Values in the data are results from Consul's /v1/health/service API.
    *
-   * The health/state endpoint returns an array of Check objects:
-   *
-   * [
-   *  {
-   *    "Node": "foobar",
-   *    "CheckID": "serfHealth",
-   *    "Name": "Serf Health Status",
-   *    "Status": "passing",
-   *    "Notes": "",
-   *    "Output": "",
-   *    "ServiceID": "",
-   *    "ServiceName": ""
-   *  },
-   *  {
-   *    "Node": "foobar",
-   *    "CheckID": "service:redis",
-   *    "Name": "Service 'redis' check",
-   *    "Status": "passing",
-   *    "Notes": "",
-   *    "Output": "",
-   *    "ServiceID": "redis",
-   *    "ServiceName": "redis"
-   *  }
-   *]
-   *
-   * The Parser builds a properties structure that looks like
-   *
-   * {
-   *   services: {
-   *     <SERVICE_ID>: {
-   *       <NODE_ID>: <NODE_ADDRESS>
-   *     }
-   *   },
-   *   nodes: {
-   *     <NODE_ID>: {
-   *       address: <NODE_ADDRESS>,
-   *       passing: <Boolean>,
-   *       checks: [Check],
-   *       services: {
-   *         <SERVICE_ID>: <Boolean>
-   *       }
-   *     }
-   *   }
-   * }
-   *
-   * Where NODE_ADDRESS is a dotted-decimal IPv4 address string. The `services` object
-   * is populated only with nodes whose respective checks are passing.
-   *
-   * @param {Array} checks
+   * @param {Object} data
    */
-  update(checks) {
-    const properties = {
-      services: {},
-      nodes: {}
-    };
+  update(data) {
+    const properties = {};
 
-    checks.forEach((check) => {
-      const serviceName = check.ServiceName;
-      const nodeID = check.Node;
-      const address = this.nodes[nodeID];
+    Object.keys(data).forEach((name) => {
+      const addresses = [];
 
-      // We don't have a catalog entry for this check's node
-      if (!address) { return; }
-
-      if (!properties.nodes[nodeID]) {
-        properties.nodes[nodeID] = {
-          address,
-          passing: true,
-          checks: [],
-          services: {}
-        };
-      }
-
-      const services = properties.nodes[nodeID].services;
-
-      properties.nodes[nodeID].checks.push({
-        id: check.CheckID,
-        name: check.Name,
-        notes: check.Notes,
-        output: check.Output,
-        service: check.ServiceName,
-        passing: check.Status === 'passing'
-      });
-
-      if (serviceName) {
-        // Set a service-check's status. One-or-more failing check -> Not Passing
-        if (!services.hasOwnProperty(serviceName)) { services[serviceName] = true; }
-        services[serviceName] = (check.Status === 'passing') && services[serviceName];
-      } else if (check.Status !== 'passing') {
-        // Update the node's global status for a node-check
-        properties.nodes[nodeID].passing = false;
-      }
-    });
-
-    // Iterate over nodes to find passing services
-    Object.keys(properties.nodes).forEach((nodeID) => {
-      const node = properties.nodes[nodeID];
-
-      // Ignore if any node-checks are failing
-      if (!node.passing) { return; }
-
-      Object.keys(node.services).forEach((serviceName) => {
-        // Ignore node-services with failing checks
-        if (!node.services[serviceName]) { return; }
-
-        if (!properties.services.hasOwnProperty(serviceName)) {
-          properties.services[serviceName] = {};
+      data[name].forEach((info) => {
+        // Prefer the service address, not the Consul agent address.
+        if (info.Service && info.Service.Address) {
+          addresses.push(info.Service.Address);
+        } else if (info.Node && info.Node.Address) {
+          addresses.push(info.Node.Address);
         }
-
-        properties.services[serviceName][nodeID] = node.address;
       });
+
+      properties[name] = {
+        cluster: name,
+        addresses: addresses
+      };
     });
 
     this.properties = properties;
-  }
-
-  /**
-   * Cache the catalog of nodes for address lookup
-   *
-   * @param  {Array} data An array of node/address tuples from the v1/catalog/nodes endpoint
-   */
-  catalog(data) {
-    this.nodes = data.reduce(function _(nodes, item) {
-      nodes[item.Node] = item.Address;
-
-      return nodes;
-    }, {});
   }
 }
 

--- a/lib/source/consul/parser.js
+++ b/lib/source/consul/parser.js
@@ -30,7 +30,7 @@ class Parser {
 
       properties[name] = {
         cluster: name,
-        addresses: addresses
+        addresses
       };
     });
 

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -207,7 +207,7 @@ describe('Conqueso API v1', () => {
       'conqueso.postgresql.ips=10.0.0.2',
       'conqueso.redis.ips=10.0.0.1',
       'conqueso.consul.ips=10.0.0.1,10.0.0.2,10.0.0.3'
-    ].join("\n");
+    ].join('\n');
 
     request(server)
       .get('/v1/conqueso/api/roles')

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -195,7 +195,6 @@ describe('Conqueso API v1', () => {
 
       done();
     });
-    consul.watcher.change();
   });
 
   afterEach((done) => {
@@ -204,7 +203,11 @@ describe('Conqueso API v1', () => {
   });
 
   it('formats IP addresses for Consul services', (done) => {
-    const expectedBody = ConsulStub.data.conqueso;
+    const expectedBody = [
+      'conqueso.postgresql.ips=10.0.0.2',
+      'conqueso.redis.ips=10.0.0.1',
+      'conqueso.consul.ips=10.0.0.1,10.0.0.2,10.0.0.3'
+    ].join("\n");
 
     request(server)
       .get('/v1/conqueso/api/roles')

--- a/test/consul.js
+++ b/test/consul.js
@@ -128,4 +128,16 @@ describe('Consul', function _() {
 
     consul.watcher.change();
   });
+
+  it('can fetch lists of services', function __(done) {
+    consul._fetch((error, data) => {
+      if (error) {
+        return done(error);
+      }
+
+      expect(data).to.equal(['consul', 'redis', 'postgresql']);
+
+      done();
+    });
+  });
 });

--- a/test/consul.js
+++ b/test/consul.js
@@ -11,6 +11,7 @@ const Consul = require('../lib/source/consul');
 
 const Net = require('net');
 const expect = require('chai').expect;
+const should = require('should');
 
 describe('Consul', function _() {
   it('instantiates a Consul Source with defaults', () => {
@@ -135,7 +136,7 @@ describe('Consul', function _() {
         return done(error);
       }
 
-      expect(data).to.equal(['consul', 'redis', 'postgresql']);
+      should(data).eql(['consul', 'postgresql', 'redis']);
 
       done();
     });

--- a/test/consul.js
+++ b/test/consul.js
@@ -130,13 +130,26 @@ describe('Consul', function _() {
     consul.watcher.change();
   });
 
-  it('can fetch lists of services', function __(done) {
+  it('can fetch lists of services with addresses', function __(done) {
     consul._fetch((error, data) => {
       if (error) {
         return done(error);
       }
 
-      should(data).eql(['consul', 'postgresql', 'redis']);
+      should(data).eql({
+        consul: {
+          cluster: 'consul',
+          addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3']
+        },
+        redis: {
+          cluster: 'redis',
+          addresses: ['10.0.0.1']
+        },
+        postgresql: {
+          cluster: 'postgresql',
+          addresses: ['10.0.0.2']
+        }
+      });
 
       done();
     });

--- a/test/consul.js
+++ b/test/consul.js
@@ -9,7 +9,6 @@ require('./lib/helpers');
 const Stub = require('./lib/stub/consul');
 const Consul = require('../lib/source/consul');
 
-const Net = require('net');
 const expect = require('chai').expect;
 
 describe('Consul', function _() {
@@ -36,9 +35,9 @@ describe('Consul', function _() {
     expect(consul.client._opts.secure).to.equal(true);
   });
 
-
   it('sets up properties on initialize', function __(done) {
     const consul = new Consul('test');
+
     consul.client = Stub;
 
     consul.initialize()
@@ -66,8 +65,9 @@ describe('Consul', function _() {
 
   it('handles errors safely', function ___(done) {
     const consul = new Consul('test');
+
     consul.client = Stub;
-    consul.client.health.service = function (options, callback) {
+    consul.client.health.service = (options, callback) => {
       callback(new Error('This is a test error!'), null);
     };
 

--- a/test/data/consul-catalog-services.json
+++ b/test/data/consul-catalog-services.json
@@ -1,0 +1,8 @@
+{
+  "consul": [],
+  "redis": [],
+  "postgresql": [
+    "master",
+    "slave"
+  ]
+}

--- a/test/data/consul-health-service.json
+++ b/test/data/consul-health-service.json
@@ -1,0 +1,95 @@
+{
+  "consul": [{
+    "Node": {
+      "Name": "redis",
+      "Address": "10.0.0.1"
+    },
+    "Service": {
+      "Name": "consul"
+    },
+    "Checks": [{
+      "Node": "redis",
+      "CheckID": "serfHealth",
+      "Status": "passing"
+    }]
+  }, {
+    "Node": {
+      "Name": "postgresql-master",
+      "Address": "127.0.0.1"
+    },
+    "Service": {
+      "Name": "consul",
+      "Address": "10.0.0.2"
+    },
+    "Checks": [{
+      "Node": "postgresql-master",
+      "CheckID": "serfHealth",
+      "Status": "passing"
+    }]
+  }, {
+    "Node": {
+      "Name": "postgresql-slave",
+      "Address": "127.0.0.1"
+    },
+    "Service": {
+      "Name": "consul",
+      "Address": "10.0.0.3"
+    },
+    "Checks": [{
+      "Node": "postgresql-master",
+      "CheckID": "serfHealth",
+      "Status": "passing"
+    }]
+  }],
+  "redis": [{
+    "Node": {
+      "Name": "redis",
+      "Address": "10.0.0.1"
+    },
+    "Service": {
+      "Name": "redis"
+    },
+    "Checks": [{
+      "Node": "redis",
+      "CheckID": "serfHealth",
+      "Status": "passing"
+    }]
+  }],
+  "postgresql": [{
+    "Node": {
+      "Name": "postgresql-master",
+      "Address": "127.0.0.1"
+    },
+    "Service": {
+      "Name": "postgresql",
+      "Address": "10.0.0.2"
+    },
+    "Checks": [{
+      "Node": "postgresql-master",
+      "CheckID": "service:postgresql",
+      "Status": "passing"
+    }, {
+      "Node": "postgresql-master",
+      "CheckID": "serfHealth",
+      "Status": "passing"
+    }]
+  }, {
+    "Node": {
+      "Name": "postgresql-slave",
+      "Address": "127.0.0.1"
+    },
+    "Service": {
+      "Name": "postgresql",
+      "Address": "10.0.0.3"
+    },
+    "Checks": [{
+      "Node": "postgresql-slave",
+      "CheckID": "service:postgresql",
+      "Status": "failing"
+    }, {
+      "Node": "postgresql-master",
+      "CheckID": "serfHealth",
+      "Status": "passing"
+    }]
+  }]
+}

--- a/test/lib/stub/consul.js
+++ b/test/lib/stub/consul.js
@@ -6,6 +6,7 @@ const EventEmitter = require('events').EventEmitter;
 const checks = require('../../data/consul-checks.json');
 const nodes = require('../../data/consul-nodes.json');
 const services = require('../../data/consul-catalog-services.json');
+const health = require('../../data/consul-health-service.json');
 
 const Parser = require('../../../lib/source/consul/parser');
 
@@ -29,6 +30,20 @@ exports.Watcher = Watcher;
 
 // Data mappings. These get passed as the `method` parameter of `watch`
 exports.health = {
+  service: function service(options, callback) {
+    const name = options.service;
+    let results = health[name];
+
+    if (options.passing) {
+      results = results.filter((node) => {
+        return !!node.Checks.every((check) => check.Status === 'passing');
+      });
+    }
+
+    setTimeout(function _() {
+      callback(null, results);
+    }, 150);
+  },
   state: checks
 };
 

--- a/test/lib/stub/consul.js
+++ b/test/lib/stub/consul.js
@@ -8,8 +8,6 @@ const nodes = require('../../data/consul-nodes.json');
 const services = require('../../data/consul-catalog-services.json');
 const health = require('../../data/consul-health-service.json');
 
-const Parser = require('../../../lib/source/consul/parser');
-
 class Watcher extends EventEmitter {
   constructor(data) {
     super();

--- a/test/lib/stub/consul.js
+++ b/test/lib/stub/consul.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events').EventEmitter;
 
 const checks = require('../../data/consul-checks.json');
 const nodes = require('../../data/consul-nodes.json');
+const services = require('../../data/consul-catalog-services.json');
 
 const Parser = require('../../../lib/source/consul/parser');
 
@@ -39,6 +40,13 @@ exports.watch = function watch(options) {
 };
 
 exports.catalog = {
+  service: {
+    list: function list(options, callback) {
+      setTimeout(function _() {
+        callback(null, services);
+      }, 150);
+    }
+  },
   node: {
     list: function list(callback) {
       // Simulate a little bit of network-service latency

--- a/test/lib/stub/consul.js
+++ b/test/lib/stub/consul.js
@@ -80,18 +80,3 @@ exports.data = {
     critical: checks.filter((check) => check.Status === 'critical')
   }
 };
-
-const parser = new Parser();
-
-parser.catalog(nodes);
-parser.update(checks);
-
-exports.data.services = parser.properties.services;
-exports.data.conqueso = Object.keys(exports.data.services)
-  .map((service) => {
-    const serviceNodes = exports.data.services[service];
-
-    return `conqueso.${service}.ips=` + Object.keys(serviceNodes)
-      .map((node) => serviceNodes[node]).join(',');
-  })
-  .join('\n');


### PR DESCRIPTION
This replaces the Consul source with a version based on polling instead of watching. This is equivalent to [the Consul source from v1.2.5](https://github.com/rapid7/propsd/blob/v1.2.5/lib/source/consul.js). We call the `/v1/catalog/services` API periodically to get a list of services, then call the `/v1/health/service/<service>` API to get a list of addresses for healthy services. Consul is polled on the same schedule as we poll S3.