### PR TITLE
Fix: Allows layers with undefined properties

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -148,6 +148,11 @@ class Properties extends EventEmitter {
    * @return {Object}               The destination object
    */
   static merge(destination, source) {
+    // Only merge source if it's an Object. `== null ` covers both null and undefined
+    if (source == null || Object.getPrototypeOf(source) !== Object.prototype) {
+      return destination;
+    }
+
     // Ensure that the destination value is an Object. `== null ` covers both null and undefined
     const dest = (destination == null ||
       Object.getPrototypeOf(destination) !== Object.prototype) ? {} : destination;

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -148,14 +148,14 @@ class Properties extends EventEmitter {
    * @return {Object}               The destination object
    */
   static merge(destination, source) {
-    // Only merge source if it's an Object. `== null ` covers both null and undefined
-    if (source == null || Object.getPrototypeOf(source) !== Object.prototype) {
-      return destination;
-    }
-
     // Ensure that the destination value is an Object. `== null ` covers both null and undefined
     const dest = (destination == null ||
       Object.getPrototypeOf(destination) !== Object.prototype) ? {} : destination;
+
+    // Only merge source if it's an Object. `== null ` covers both null and undefined
+    if (source == null || Object.getPrototypeOf(source) !== Object.prototype) {
+      return dest;
+    }
 
     Object.keys(source).forEach((key) => {
       // Ignore null and undefined source values. `== null` covers both

--- a/test/properties.js
+++ b/test/properties.js
@@ -285,6 +285,18 @@ describe('Properties', function _() {
       });
     });
 
+    it('always returns an Object', function ___() {
+      const a = [];
+      const b = null;
+
+      const c = Properties.merge(a, b);
+
+      expect(c).to.not.equal(a);
+      expect(c).to.not.equal(b);
+      expect(c).to.be.instanceOf(Object);
+      expect(c).to.deep.equal({});
+    });
+
     it('does not attempt to merge values that aren\'t direct descendants of Object', function ___() {
       const a = {
         a: 2, c: {

--- a/test/properties.js
+++ b/test/properties.js
@@ -268,6 +268,23 @@ describe('Properties', function _() {
       expect(c).to.deep.equal({a: 1});
     });
 
+    it('avoids merging keys with null or undefined values', function ___() {
+      const a = {a: 0};
+      const b = {
+        z: 1,
+        n: null,
+        u: undefined
+      };
+
+      const c = Properties.merge(a, b);
+
+      expect(c).to.equal(a);
+      expect(c).to.deep.equal({
+        a: 0,
+        z: 1
+      });
+    });
+
     it('does not attempt to merge values that aren\'t direct descendants of Object', function ___() {
       const a = {
         a: 2, c: {

--- a/test/properties.js
+++ b/test/properties.js
@@ -258,7 +258,7 @@ describe('Properties', function _() {
       expect(c).to.deep.equal({a: 1});
     });
 
-    it('instantiates a new object for source when null or undefined are passed', function ___() {
+    it('avoids merging source when null or undefined are passed', function ___() {
       const a = {a: 1};
       const b = null;
 

--- a/test/properties.js
+++ b/test/properties.js
@@ -258,6 +258,16 @@ describe('Properties', function _() {
       expect(c).to.deep.equal({a: 1});
     });
 
+    it('instantiates a new object for source when null or undefined are passed', function ___() {
+      const a = {a: 1};
+      const b = null;
+
+      const c = Properties.merge(a, b);
+
+      expect(c).to.equal(a);
+      expect(c).to.deep.equal({a: 1});
+    });
+
     it('does not attempt to merge values that aren\'t direct descendants of Object', function ___() {
       const a = {
         a: 2, c: {


### PR DESCRIPTION
This fixes a bug where propsd wouldn't start if you didn't have any properties defined statically in your config file.