### PR TITLE
Feature: Document Consul config

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -94,6 +94,24 @@ The configuration file below is the default settings for propsd.
   * `interval` - The time in milliseconds to poll the index property file for
     changes. Defaults to 30000 (30 seconds).
 
+* `consul` - These settings control service discovery via [Consul][].
+
+  Propsd can use Consul for service discovery. Services registered with Consul
+  show up in propsd as properties that look like "conqueso.service.ips=127.0.0.1".
+  IP addresses are comma separated and only services whose health checks are all
+  passing will be reported. Consul is polled periodically for changes. This
+  allows service discovery to happen without requiring a restart of propsd.
+
+  * `host` - The host to connect to Consul on. Defaults to 127.0.0.1.
+
+  * `port` - The HTTP port to connect to Consul on. Defaults to 8500.
+
+  * `secure` - Whether to use HTTPS when connecting to Consul. Defaults to false
+    and uses HTTP.
+
+  * `interval` - The time in milliseconds to poll Consul for changes. Defaults
+    to 60000 (60 seconds).
+
 * `properties` - An arbitrary JSON object for injecting values into the index.
 
   Propsd supports treating the index document as a template and injecting
@@ -148,3 +166,6 @@ Interpolated properties in templated documents are enclosed in double curly
 braces: `{{` and `}}`. The value betwen the double curly braces is a key from
 the `properties` object. Nested keys within the `properties` object are
 accessed by separating the keys with colons.
+
+
+[Consul]: https://www.consul.io/

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -70,7 +70,7 @@ The configuration file below is the default settings for propsd.
   The following keys are available:
 
   * `level` - The level to log at. Valid values are "debug", "verbose", "info",
-    "warn", and "error". Each log level encompases all the ones below it. So
+    "warn", and "error". Each log level encompasses all the ones below it. So
     "debug" is the most verbose and "error" is the least verbose. Defaults to
     "info".
 
@@ -78,7 +78,7 @@ The configuration file below is the default settings for propsd.
 
   Propsd reads properties from files stored in Amazon S3. Property files are
   JSON documents. A single property file must be configured as an index that
-  lists other property files to read. Property files are polled periodicaly for
+  lists other property files to read. Property files are polled periodically for
   changes. This allows new property files to be read at run time without
   requiring a restart of propsd.
 
@@ -126,12 +126,12 @@ property documents read from S3. This provides a way to read instance specific
 properties.
 
 Suppose you have two configurations for metrics polling, fast and slow. Fast
-polls every thrity seconds and the configuration for it lives in
+polls every thirty seconds and the configuration for it lives in
 a `metrics/fast.json` document in S3. Slow polls every five minutes, and the
 configuration for it lives in a `metrics/slow.json` document in S3.
 
 Interpolated properties let you configure propsd to read either the fast or
-slow document. You start by adding a `{{speed}}` template paramter to your
+slow document. You start by adding a `{{speed}}` template parameter to your
 `index.json` document in S3.
 
 ~~~json
@@ -163,7 +163,7 @@ If the `properties:speed` key was configured as "slow", the `metrics/slow.json`
 document would be read instead.
 
 Interpolated properties in templated documents are enclosed in double curly
-braces: `{{` and `}}`. The value betwen the double curly braces is a key from
+braces: `{{` and `}}`. The value between the double curly braces is a key from
 the `properties` object. Nested keys within the `properties` object are
 accessed by separating the keys with colons.
 

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -40,8 +40,10 @@ request to `/v1/health` and you'll see output similar to this:
   "status": 200,
   "uptime": 3193957,
   "plugins": {
-    "s3": 1
-  }
+    "s3": 1,
+    "consul": 1,
+  },
+  "version": "1.2.5"
 }
 ~~~
 
@@ -49,7 +51,7 @@ The "status" attribute is the response code. Response codes from the health
 endpoint are compatible with [Consul's HTTP health checks][consul]. The
 "uptime" attribute is the number of milliseconds the service has been running.
 The "plugins" attribute is a map from plugin type to the number of instances of
-the plugin that are running.
+the plugin that are running. The "version" attribute is the version of propsd.
 
 The second endpoint is a status endpoint that provides detailed information
 about propsd. Issue a GET request to `/v1/status` and you'll see output

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -63,24 +63,45 @@ similar to this:
   "uptime": 18160502,
   "index": {
     "running": true,
+    "name": "index",
+    "type": "s3",
+    "ok": true,
+    "state": "RUNNING",
+    "updated": "2016-06-10T14:53:08.453Z",
     "interval": 30000,
-    "updated": "2016-04-25T13:00:04.257Z",
-    "ok": true
+    "resource": "s3://bucket/index.json",
+    "etag": "e81944e6e597d8e9e5db01b1cf9dfd7d"
   },
   "sources": [
     {
       "status": "okay",
+      "interval": 60000,
+      "updated": "2016-06-10T18:45:07.182Z",
+      "state": "RUNNING",
+      "ok": true,
+      "type": "consul",
+      "name": "consul"
+    },
+    {
+      "status": "okay",
+      "name": "global",
       "type": "s3",
-      "name": "s3-config.propsd-global.json"
+      "ok": true,
+      "state": "RUNNING",
+      "updated": "2016-06-10T14:53:09.613Z",
+      "interval": 60000,
+      "resource": "s3://bucket/global.json",
+      "etag": "4856c7b6c749068ea986f23668a41c46"
     }
-  ]
+  ],
+  "vesion": "1.2.6"
 }
 ~~~
 
-The "status" and "uptime" attributes match the ones from the health endpoint.
-The "index" attribute provides metadata about the index property file, such as
-the last time it was updated. The "sources" array provides metadata about each
-of the sources propsd is reading properties from.
+The "status", "uptime", and "version" attributes match the ones from the health
+endpoint. The "index" attribute provides metadata about the index property file,
+such as the last time it was updated. The "sources" array provides metadata
+about each of the sources propsd is reading properties from.
 
 ## Index Files ##
 


### PR DESCRIPTION
This fixes #138. Documentation around how to configure propsd so it can use [Consul](https://www.consul.io/) for service discovery is provided. Additionally, the example `/v1/health` and `/v1/status` outputs have been updated to reflect the new metadata included in this refactor.