### PR TITLE
Fix: S3 ETag caching

### DIFF
--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -139,7 +139,7 @@ class Source extends EventEmitter {
 
       // Emit an update if the source no longer exists
       if (previousState !== Source.WAITING) {
-        Log.log('DEBUG', `Source ${this.type} source ${this.name} no longer exists`, this.status());
+        Log.log('INFO', `Source ${this.type} source ${this.name} no longer exists`, this.status());
         this.emit('update', this);
       }
 

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -105,6 +105,8 @@ class Source extends EventEmitter {
     return this.state !== Source.ERROR && this.state !== Source.WARNING;
   }
 
+  /* eslint-disable max-statements */
+
   /**
    * Called by implementations to update source data
    *
@@ -169,6 +171,8 @@ class Source extends EventEmitter {
     this.emit('update', this);
     return this;
   }
+
+  /* eslint-enable max-statements */
 
   /**
    * Handle errors from underlying source facilities

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -113,6 +113,8 @@ class Source extends EventEmitter {
    * @private
    */
   _update(data) {
+    const previousState = this.state;
+
     // No changes to the source's data have occurred since the last update
     if (data === Source.NO_UPDATE) {
       this.emit('noupdate', this);
@@ -121,39 +123,25 @@ class Source extends EventEmitter {
 
     // The source's underlying data resource does not exist
     if (data === Source.NO_EXIST) {
-      switch (this.state) {
-        case Source.INITIALIZING:
-          this.state = Source.WAITING;
+      this.state = Source.WAITING;
 
-          // Resolve the initialize promise
-          this.emit('initialized', this);
-          return this;
+      // Clear previous properties and state
+      this.properties = {};
+      this._state = null;
+      this.updated = new Date();
 
-        case Source.RUNNING:
-          this.state = Source.WAITING;
-
-          // Clear previous properties and state
-          this.properties = {};
-          this._state = null;
-          this.updated = new Date();
-
-          Log.log('DEBUG', `Source ${this.type} source ${this.name} no longer exists`, this.status());
-
-          // Notify watchers
-          this.emit('update', this);
-          return this;
-
-        case Source.WARNING:
-        case Source.ERROR:
-
-          // There was some kind of a successful response. Not an ERROR
-          // or WARNING anymore.
-          this.state = Source.WAITING;
-          return this;
-
-        default:
-          return this;
+      // Resolve the initialize promise
+      if (previousState === Source.INITIALIZING) {
+        this.emit('initialized', this);
       }
+
+      // Emit an update if the source no longer exists
+      if (previousState !== Source.WAITING) {
+        Log.log('DEBUG', `Source ${this.type} source ${this.name} no longer exists`, this.status());
+        this.emit('update', this);
+      }
+
+      return this;
     }
 
     try {
@@ -161,8 +149,6 @@ class Source extends EventEmitter {
     } catch (e) {
       return this._error(e);
     }
-
-    const previousState = this.state;
 
     // Successful update indicates a RUNNING state
     this.state = Source.RUNNING;

--- a/lib/source/common.js
+++ b/lib/source/common.js
@@ -132,8 +132,9 @@ class Source extends EventEmitter {
         case Source.RUNNING:
           this.state = Source.WAITING;
 
-          // Clear previous properties
+          // Clear previous properties and state
           this.properties = {};
+          this._state = null;
           this.updated = new Date();
 
           Log.log('DEBUG', `Source ${this.type} source ${this.name} no longer exists`, this.status());

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -79,6 +79,7 @@ class S3 extends Source.Polling(S3Parser) { // eslint-disable-line new-cap
         }
 
         if (err.code === 'NoSuchKey') {
+          this._state = null;
           return callback(null, Source.NO_EXIST);
         }
 

--- a/lib/source/s3.js
+++ b/lib/source/s3.js
@@ -79,7 +79,6 @@ class S3 extends Source.Polling(S3Parser) { // eslint-disable-line new-cap
         }
 
         if (err.code === 'NoSuchKey') {
-          this._state = null;
           return callback(null, Source.NO_EXIST);
         }
 

--- a/test/s3.js
+++ b/test/s3.js
@@ -173,6 +173,25 @@ describe('S3 source plugin', function () {
     s3OtherError.initialize();
   });
 
+  it('clears ETag but not properites if getRequest returns an error', (done) => {
+    const Stub = s3Stub({
+      getObject: sinon.stub().callsArgWith(1, {code: 'BigTimeErrorCode', message: 'This is the error message'}, null)
+    });
+    const s3OtherError = new Stub('foo.json', {bucket: DEFAULT_BUCKET, path: 'foo.json'});
+
+    s3OtherError.once('error', () => {
+      should(s3OtherError.status().etag).be.null();
+      should(s3OtherError.properties).eql({foo: 'bar'});
+      done();
+    });
+
+    s3OtherError.state = Source.RUNNING;
+    s3OtherError._state = 'ThisIsACoolEtag';
+    s3OtherError.properties = {foo: 'bar'};
+
+    s3OtherError.start();
+  });
+
   it('can\'t shutdown a plugin that\'s already shut down', (done) => {
     const shutdownSpy = sinon.spy();
 

--- a/test/s3.js
+++ b/test/s3.js
@@ -120,6 +120,21 @@ describe('S3 source plugin', function () {
     s3WithNoSuchKeyError.start();
   });
 
+  it('clears the ETag if getRequest returns a NoSuchKey error', (done) => {
+    const Stub = s3Stub({getObject: sinon.stub().callsArgWith(1, {code: 'NoSuchKey'}, null)});
+    const s3WithNoSuchKeyError = new Stub('foo.json', {bucket: DEFAULT_BUCKET, path: 'foo.json'});
+
+    s3WithNoSuchKeyError.once('update', () => {
+      should(s3WithNoSuchKeyError.status().etag).be.null();
+      done();
+    });
+
+    s3WithNoSuchKeyError.state = Source.RUNNING;
+    s3WithNoSuchKeyError._state = 'ThisIsACoolEtag';
+
+    s3WithNoSuchKeyError.start();
+  });
+
   it('doesn\'t do anything if getRequest returns a NotModified error', (done) => {
     const errorSpy = sinon.spy();
     const updateSpy = sinon.spy();

--- a/test/source-common.js
+++ b/test/source-common.js
@@ -95,6 +95,19 @@ describe('Source/Common', function _() {
     expect(new Source.PollingStub()).to.be.instanceOf(Source.Common.Polling);
   });
 
+  it('clears properties and state on NO_EXISTS when INITIALIZING', function __() {
+    const source = new Source.Stub({key: 'value'});
+
+    source.state = Source.Common.INITIALIZING;
+    source._state = 'non-null-value';
+
+    source._update(Source.Common.NO_EXIST);
+
+    expect(source.state).to.eql(Source.Common.WAITING);
+    expect(source.properties).to.eql({});
+    expect(source._state).to.eql(null);
+  });
+
   it('clears properties and state on NO_EXISTS when RUNNING', function __() {
     const source = new Source.Stub({key: 'value'});
 

--- a/test/source-common.js
+++ b/test/source-common.js
@@ -95,7 +95,7 @@ describe('Source/Common', function _() {
     expect(new Source.PollingStub()).to.be.instanceOf(Source.Common.Polling);
   });
 
-  it('clears properties and state on NO_EXISTS when INITIALIZING', function __() {
+  it('clears properties and state on NO_EXIST when INITIALIZING', function __() {
     const source = new Source.Stub({key: 'value'});
 
     source.state = Source.Common.INITIALIZING;
@@ -108,7 +108,7 @@ describe('Source/Common', function _() {
     expect(source._state).to.eql(null);
   });
 
-  it('clears properties and state on NO_EXISTS when RUNNING', function __() {
+  it('clears properties and state on NO_EXIST when RUNNING', function __() {
     const source = new Source.Stub({key: 'value'});
 
     source.state = Source.Common.RUNNING;
@@ -121,7 +121,7 @@ describe('Source/Common', function _() {
     expect(source._state).to.eql(null);
   });
 
-  it('clears properties and state on NO_EXISTS when WARNING', function __() {
+  it('clears properties and state on NO_EXIST when WARNING', function __() {
     const source = new Source.Stub({key: 'value'});
 
     source.state = Source.Common.WARNING;
@@ -134,7 +134,7 @@ describe('Source/Common', function _() {
     expect(source._state).to.eql(null);
   });
 
-  it('clears properties and state on NO_EXISTS when ERROR', function __() {
+  it('clears properties and state on NO_EXIST when ERROR', function __() {
     const source = new Source.Stub({key: 'value'});
 
     source.state = Source.Common.ERROR;
@@ -147,7 +147,7 @@ describe('Source/Common', function _() {
     expect(source._state).to.eql(null);
   });
 
-  it('clears properties and state on NO_EXISTS when WAITING', function __() {
+  it('clears properties and state on NO_EXIST when WAITING', function __() {
     const source = new Source.Stub({key: 'value'});
 
     source.state = Source.Common.WAITING;

--- a/test/source-common.js
+++ b/test/source-common.js
@@ -147,7 +147,7 @@ describe('Source/Common', function _() {
     expect(source._state).to.eql(null);
   });
 
-  it('retains properties and state on NO_EXISTS when WAITING', function __() {
+  it('clears properties and state on NO_EXISTS when WAITING', function __() {
     const source = new Source.Stub({key: 'value'});
 
     source.state = Source.Common.WAITING;
@@ -156,8 +156,8 @@ describe('Source/Common', function _() {
     source._update(Source.Common.NO_EXIST);
 
     expect(source.state).to.eql(Source.Common.WAITING);
-    expect(source.properties).to.eql({key: 'value'});
-    expect(source._state).to.eql('non-null-value');
+    expect(source.properties).to.eql({});
+    expect(source._state).to.eql(null);
   });
 
   describe('Polling', function __() {

--- a/test/source-common.js
+++ b/test/source-common.js
@@ -95,6 +95,58 @@ describe('Source/Common', function _() {
     expect(new Source.PollingStub()).to.be.instanceOf(Source.Common.Polling);
   });
 
+  it('clears properties and state on NO_EXISTS when RUNNING', function __() {
+    const source = new Source.Stub({key: 'value'});
+
+    source.state = Source.Common.RUNNING;
+    source._state = 'non-null-value';
+
+    source._update(Source.Common.NO_EXIST);
+
+    expect(source.state).to.eql(Source.Common.WAITING);
+    expect(source.properties).to.eql({});
+    expect(source._state).to.eql(null);
+  });
+
+  it('clears properties and state on NO_EXISTS when WARNING', function __() {
+    const source = new Source.Stub({key: 'value'});
+
+    source.state = Source.Common.WARNING;
+    source._state = 'non-null-value';
+
+    source._update(Source.Common.NO_EXIST);
+
+    expect(source.state).to.eql(Source.Common.WAITING);
+    expect(source.properties).to.eql({});
+    expect(source._state).to.eql(null);
+  });
+
+  it('clears properties and state on NO_EXISTS when ERROR', function __() {
+    const source = new Source.Stub({key: 'value'});
+
+    source.state = Source.Common.ERROR;
+    source._state = 'non-null-value';
+
+    source._update(Source.Common.NO_EXIST);
+
+    expect(source.state).to.eql(Source.Common.WAITING);
+    expect(source.properties).to.eql({});
+    expect(source._state).to.eql(null);
+  });
+
+  it('retains properties and state on NO_EXISTS when WAITING', function __() {
+    const source = new Source.Stub({key: 'value'});
+
+    source.state = Source.Common.WAITING;
+    source._state = 'non-null-value';
+
+    source._update(Source.Common.NO_EXIST);
+
+    expect(source.state).to.eql(Source.Common.WAITING);
+    expect(source.properties).to.eql({key: 'value'});
+    expect(source._state).to.eql('non-null-value');
+  });
+
   describe('Polling', function __() {
     it('sets an interval', function ___() {
       const stub = new Source.PollingStub({}, {


### PR DESCRIPTION
This fixes #178. The ETag for an S3 source is now explicitly cleared when a `NoSuchKey` error is returned from AWS. This ensures propsd will get properties from the source when it becomes available.

The fix applies to all polling sources. Currently, only the S3 source takes advantage of it.