### PR TITLE
Let chef set the default mode on the symlink

### DIFF
--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -61,7 +61,6 @@ link node['propsd']['paths']['directory'] do
   to version_dir
   owner node['propsd']['user']
   group node['propsd']['group']
-  mode '0755'
 end
 
 ## Chown the contents of the versioned propsd directory to the propsd user/group


### PR DESCRIPTION
Fixes a bug where propsd is restarted every time a chef run is done because permissions are being changed from `777` to `755`.