### PR TITLE
Add Propsd Ohai Plugin

### DIFF
--- a/Buildfile
+++ b/Buildfile
@@ -7,6 +7,6 @@ cookbook.depends 'propsd' do |propsd|
   propsd.path './cookbook'
 end
 
-profile :default do |default|
-  default.chef.run_list 'propsd::default'
+profile :default do |test|
+  test.chef.run_list 'propsd::test'
 end

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -4,11 +4,11 @@
 
 ### default.rb
 
-Install and configure propsd.  You will need to overide the `propsd-configuration` and the `props-service` to do anything useful; see the `test.rb` recipe for an example.  
+Install and configure Propsd.  You will need to overide the `propsd-configuration` and the `props-service` to do anything useful; see the `test.rb` recipe for an example.  
 
 ### ohai_plugin.rb
 
-Install propsd ohai plugin
+Install Propsd Ohai plugin
 
 ## Attributes
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,0 +1,25 @@
+# Propsd Cookbook
+
+## Recipies
+
+### default.rb
+
+Install and configure propsd.  You will need to overide the `propsd-configuration` and the `props-service` to do anything useful; see the `test.rb` recipe for an example.  
+
+### ohai_plugin.rb
+
+Install propsd ohai plugin
+
+## Attributes
+
+* `node['propsd']['user']` - User that owns the Propsd installation (default: `propsd`)
+* `node['propsd']['group']` - Group that owns the Propsd installation (default: `propsd`)
+* `node['propsd']['paths']['directory']` - The location of the Propsd installation (default: `/opt/propsd`)
+* `node['propsd']['paths']['configuration']` - The location of the Propsd configuration file (default: `/etc/propsd/config.json`)
+* `node['propsd']['ohai_plugin_path']` - Ohai Plugin Path; directory the Propsd plugin will get installed 
+
+## Usage
+
+Simply add `recipe[propsd::default]` to a run list.
+
+Additionally, to use the ohai plugin add `recipe[propsd::ohai_plugin]` to a run list.

--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -8,3 +8,5 @@ default['propsd']['paths']['configuration'] = '/etc/propsd/config.json'
 
 default['propsd']['config'] = Mash.new
 default['propsd']['version'] = nil
+
+default['propsd']['ohai_plugin_path'] = nil

--- a/cookbook/files/default/propsd_ohai_plugin.rb
+++ b/cookbook/files/default/propsd_ohai_plugin.rb
@@ -1,0 +1,70 @@
+require 'json'
+
+Ohai.plugin(:Propsd) do
+  provides 'propsd_plugin'
+
+  PROPSD_HOST = 'localhost' unless defined?(PROPSD_HOST)
+  PROPSD_PORT = 9100 unless defined?(PROPSD_PORT)
+
+  def can_propsd_connect?(addr, port, timeout = 2)
+    t = Socket.new(Socket::Constants::AF_INET, Socket::Constants::SOCK_STREAM, 0)
+    saddr = Socket.pack_sockaddr_in(port, addr)
+    connected = false
+
+    begin
+      t.connect_nonblock(saddr)
+    rescue Errno::EINPROGRESS
+      r, w, e = IO.select(nil, [t], nil, timeout)
+      if !w.nil?
+        connected = true
+      else
+        begin
+          t.connect_nonblock(saddr)
+        rescue Errno::EISCONN
+          t.close
+          connected = true
+        rescue SystemCallError
+        end
+      end
+    rescue SystemCallError
+    end
+    Ohai::Log.debug("can_propsd_connect? == #{connected}")
+    connected
+  end
+
+  def get_properties_from_file
+    f = ::File.open('/vagrant/properties.json', 'r').read
+    props = ::JSON.parse(f)
+    props
+  rescue Exception => e
+    Ohai::Log.error(e)
+  end
+
+  def get_properties
+    response = http_client.get('/v1/properties')
+    if response.code != "200"
+      raise 'Unable to get properties from propsd'
+    else
+      props = response.body
+      props = ::JSON.parse(props)
+    end
+  rescue JSON::JSONError
+    raise 'Error parsing JSON properties'
+  rescue StandardError
+    raise 'Error connecting to propsd'
+  end
+
+  def http_client
+    Net::HTTP.start(PROPSD_HOST, PROPSD_PORT).tap { |h| h.read_timeout = 30 }
+  end
+
+  collect_data(:default) do
+    propsd_plugin Mash.new
+    if can_propsd_connect?(PROPSD_HOST, PROPSD_PORT)
+      props = get_properties
+      props.each_pair do |k,v|
+        propsd[k] = v
+      end
+    end
+  end
+end

--- a/cookbook/files/default/propsd_ohai_plugin.rb
+++ b/cookbook/files/default/propsd_ohai_plugin.rb
@@ -32,14 +32,6 @@ Ohai.plugin(:Propsd) do
     connected
   end
 
-  def get_properties_from_file
-    f = ::File.open('/vagrant/properties.json', 'r').read
-    props = ::JSON.parse(f)
-    props
-  rescue Exception => e
-    Ohai::Log.error(e)
-  end
-
   def get_properties
     response = http_client.get('/v1/properties')
     if response.code != "200"

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -16,3 +16,4 @@ long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 
 depends 'apt'
+depends 'ohai', '~> 4.2'

--- a/cookbook/recipes/ohai_plugin.rb
+++ b/cookbook/recipes/ohai_plugin.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: propsd
+# Recipe:: ohai_plugin
+#
+# Copyright (C) 2016 Rapid7 LLC.
+#
+# Distributed under terms of the MIT License. All rights not explicitly granted
+# in the MIT license are reserved. See the included LICENSE file for more details.
+#
+
+ohai_plugin 'propsd_ohai_plugin' do
+  path node['propsd']['ohai_plugin_path']
+end

--- a/cookbook/recipes/test.rb
+++ b/cookbook/recipes/test.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: propsd
+# Recipe:: test
+#
+# Copyright (C) 2016 Rapid7 LLC.
+#
+# Distributed under terms of the MIT License. All rights not explicitly granted
+# in the MIT license are reserved. See the included LICENSE file for more details.
+#
+
+node.default['propsd']['config']['index']['bucket'] = 'my.test.bucket'
+
+include_recipe 'propsd::default'
+
+resources('service[propsd]').action([:start, :enable])
+
+include_recipe "#{ cookbook_name}::ohai_plugin"
+
+::Chef::Log.info("PROPSD PLUGIN -- #{node['propsd_plugin']}")


### PR DESCRIPTION
This PR adds an Ohai plugin for Propsd.  This gives you access to all of the properties found in the Propsd `/properties` api from within Chef.

This plugin is optional, in-order to use it add `propsd::ohai_plugin` to a run_list.

The of the properties are available under the `node['propsd_plugin']` key.

