### PR TITLE
Fixes Mash name

### DIFF
--- a/cookbook/files/default/propsd_ohai_plugin.rb
+++ b/cookbook/files/default/propsd_ohai_plugin.rb
@@ -55,7 +55,7 @@ Ohai.plugin(:Propsd) do
     if can_propsd_connect?(PROPSD_HOST, PROPSD_PORT)
       props = get_properties
       props.each_pair do |k,v|
-        propsd[k] = v
+        propsd_plugin[k] = v
       end
     end
   end


### PR DESCRIPTION
This change fixes the name of the Mash we are assigning values.  This
was missed in a final refactor to #186.