### PR TITLE
Bug: Rake task packs dev dependencies on older versions of npm

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ def base_dir
 end
 
 task :install do
-  sh 'npm install --only=prod'
+  sh 'npm install --production'
 end
 
 task :shrinkwrap => [:install] do


### PR DESCRIPTION
The `--only` flag is supported under npm 3+. Because we're pinned to LTS, we're using npm 2.x so all packages were being installed.