### PR TITLE
Suppress EC2 metadata client errors for non-existent paths

### DIFF
--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -64,16 +64,16 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
 
       // Call `Metadata.request` for each path
       (path, cb) => this.service.request(path, (err, value) => {
-        if (err && err.message === null) {
+        if (err) {
           /*
-           * This is really great. AWS-SDK > 2.6ish now raises an error with a null
-           * message when a requested metadata path doesn't exist. We don't want
-           * to abort the rest of the traversal for this.
+           * AWS-SDK > 2.6.0 now raises an error with a null message when the underlying http
+           * request returns a non-2xx status code. We don't want to abort the rest of the traversal
+           * for this. Instead, log the error and swallow it.
            */
-
-          return cb(null, false);
+          Log.log('ERROR', 'Aws-sdk returned the following error during the metadata service request ' +
+              `to ${path}: %j`, err);
+          cb(null, false);
         }
-
         cb(err, value);
       }),
 

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -72,7 +72,7 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
            */
           Log.log('ERROR', 'Aws-sdk returned the following error during the metadata service request ' +
               `to ${path}: %j`, err);
-          cb(null, false);
+          return cb(null, false);
         }
         cb(err, value);
       }),

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -63,7 +63,19 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
     Util.traverse(this.version, Parser.paths,
 
       // Call `Metadata.request` for each path
-      (path, cb) => this.service.request(path, cb),
+      (path, cb) => this.service.request(path, (err, value) => {
+        if (err && err.message === null) {
+          /*
+           * This is really great. AWS-SDK > 2.6ish now raises an error with a null
+           * message when a requested metadata path doesn't exist. We don't want
+           * to abort the rest of the traversal for this.
+           */
+
+          return cb(null, false);
+        }
+
+        cb(err, value);
+      }),
 
       // Handle results of metadata tree traversal
       (err, data) => {


### PR DESCRIPTION
Somewhere in aws-sdk@2.6 the behavior of the metadata service client changed to start raising errors for 404 responses. This change catches and suppresses those errors.