### PR TITLE
Bug layer ordering reversed

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -54,9 +54,9 @@ const properties = new Properties();
 const sources = new Sources(properties);
 
 // Add metadata and some statics
-properties.static(Config.get('properties'));
-properties.dynamic(new Metadata(Config.get('metadata')), 'instance');
 properties.dynamic(new Consul('consul', Config.get('consul')), 'consul');
+properties.dynamic(new Metadata(Config.get('metadata')), 'instance');
+properties.static(Config.get('properties'));
 
 // Create the Index source
 sources.index(new S3('index', Config.get('index')));

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -29,9 +29,8 @@ class Properties extends EventEmitter {
       // Get Dynamic layers' source instances
       .concat(this.layers.map((layer) => layer.source).filter((source) => !!source))
 
-      // Add the active View's sources. Reversed for precedence consistency with Layers:
-      // Entry 0 is most precedent, LAST is least precedent.
-      .concat(this.active.sources.reverse());
+      // Add the active View's sources.
+      .concat(this.active.sources);
   }
 
   /**

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -112,9 +112,6 @@ class Properties extends EventEmitter {
       const persistent = {};
 
       this.layers
-
-        // Merge layers in reverse. `layers[0]` is the most precedent
-        .reverse()
         .forEach((layer) => {
           if (!layer.namespace) {
             return Properties.merge(persistent, layer.properties);

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -30,6 +30,8 @@ class Properties extends EventEmitter {
       .concat(this.layers.map((layer) => layer.source).filter((source) => !!source))
 
       // Add the active View's sources.
+      //  NOTE: This is a shallow copy and only copies object references to a new array.
+      //  DO NOT USE THIS GETTER TO PERFORM ANY MUTATING ACTIVITIES.
       .concat(this.active.sources.slice().reverse());
   }
 

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -30,7 +30,7 @@ class Properties extends EventEmitter {
       .concat(this.layers.map((layer) => layer.source).filter((source) => !!source))
 
       // Add the active View's sources.
-      .concat(this.active.sources);
+      .concat(this.active.sources.slice().reverse());
   }
 
   /**

--- a/test/properties.js
+++ b/test/properties.js
@@ -8,7 +8,6 @@ require('./lib/helpers');
 
 const Properties = require('../lib/properties');
 const Source = require('./lib/stub/source');
-const S3 = require('../lib/source/s3');
 
 // Shorten build hold-down timeout for testing
 Properties.BUILD_HOLD_DOWN = 100;
@@ -37,22 +36,23 @@ describe('Properties', function _() {
 
   it('does not reorder source layers if build is called multiple times', function __(done) {
     const localProps = new Properties();
-    const correctOrder = ['hello', 'world'];
+    const correctOrder = ['first', 'second'];
 
     localProps.static({
       hello: 'world'
-    });
+    }, 'first');
     localProps.static({
       world: 'hello'
-    });
+    }, 'second');
 
     let ranOnce = false;
 
     localProps.on('build', () => {
-      const layerKeys = [].concat.apply([], localProps.layers.map((i) => Object.keys(i.properties)));
+      const layerKeys = localProps.layers.map((i) => i.namespace);
 
       expect(layerKeys).to.eql(correctOrder);
       if (ranOnce) {
+        expect(layerKeys).to.eql(correctOrder);
         done();
       }
       ranOnce = true;
@@ -64,27 +64,22 @@ describe('Properties', function _() {
   });
 
   it('does not reorder layers if the properties sources getter is called', function ___(done) {
-    const localProps = new Properties();
-    const correctOrder = ['foo-bar-baz.json', 'foo-quiz-buzz.json'];
+    const props = new Properties();
+    const sources = [
+      new Source.Stub({path: 'foo'}),
+      new Source.Stub({path: 'bar'}),
+      new Source.Stub({path: 'baz'})
+    ];
+    const view = props.view(sources);
 
-    localProps.dynamic(new S3('foo-bar-baz.json', {
-      bucket: 'test-bucket',
-      path: 'foo-bar-baz.json'
-    }), 'test');
-
-    localProps.dynamic(new S3('foo-quiz-buzz.json', {
-      bucket: 'test-bucket',
-      path: 'foo-quiz-buzz.json'
-    }), 'test');
-
-    const view = localProps.view();
-
-    localProps.on('build', () => {
-      expect(localProps.sources.map((s) => s.name)).to.eql(correctOrder);
-      done();
+    props.once('build', () => {
+      expect(props.sources.map((s) => s.properties.path)).to.eql(['foo', 'bar', 'baz']);
     });
 
-    view.activate();
+    view.activate().then(() => {
+      expect(props.sources.map((s) => s.properties.path)).to.eql(['foo', 'bar', 'baz']);
+      done();
+    });
   });
 
   it('adds layers with namespaces', function __(done) {

--- a/test/properties.js
+++ b/test/properties.js
@@ -71,13 +71,14 @@ describe('Properties', function _() {
       new Source.Stub({path: 'baz'})
     ];
     const view = props.view(sources);
+    const expected = ['baz', 'bar', 'foo'];
 
     props.once('build', () => {
-      expect(props.sources.map((s) => s.properties.path)).to.eql(['foo', 'bar', 'baz']);
+      expect(props.sources.map((s) => s.properties.path)).to.eql(expected);
     });
 
     view.activate().then(() => {
-      expect(props.sources.map((s) => s.properties.path)).to.eql(['foo', 'bar', 'baz']);
+      expect(props.sources.map((s) => s.properties.path)).to.eql(expected);
       done();
     });
   });

--- a/test/properties.js
+++ b/test/properties.js
@@ -71,16 +71,16 @@ describe('Properties', function _() {
       new Source.Stub({path: 'baz'})
     ];
     const view = props.view(sources);
-    const expected = ['baz', 'bar', 'foo'];
+    const expected = ['foo', 'bar', 'baz'];
+    const reversed = ['baz', 'bar', 'foo'];
 
     props.once('build', () => {
-      expect(props.sources.map((s) => s.properties.path)).to.eql(expected);
-    });
-
-    view.activate().then(() => {
-      expect(props.sources.map((s) => s.properties.path)).to.eql(expected);
+      expect(props.sources.map((s) => s.properties.path)).to.eql(reversed);
+      expect(props.active.sources.map((s) => s.properties.path)).to.eql(expected);
       done();
     });
+
+    view.activate();
   });
 
   it('adds layers with namespaces', function __(done) {


### PR DESCRIPTION
This PR refactors the `Properties` class to never reverse internal arrays. This fixes problems where the `Properties#sources` getter and `Properties#build()` were mutating objects in place. It reverses the order in which Consul, EC2 Metadata, and static properties are loaded in `server.js`.

Resolves #189 and supersedes #192 and #196. 

