### PR TITLE
GitHub release task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gem 'aws-sdk', '~> 2.2'
 gem 'fpm', '~> 1.4'
-
+gem 'octokit', '~> 4.0'
 gem 'builderator', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ DEPENDENCIES
   aws-sdk (~> 2.2)
   builderator (~> 1.0)
   fpm (~> 1.4)
+  octokit (~> 4.0)
 
 BUNDLED WITH
    1.12.5

--- a/README.md
+++ b/README.md
@@ -101,11 +101,14 @@ To cut a release do the following:
 
 This can be accomplished by running the following commands:
 ~~~bash
-npm version minor
-rake
+$ npm version minor
+$ bundle exec rake default
 ~~~
-Then following the steps to create the release on github.com
+To be able to create a new release on [github.com], you must have the following environment variables set:
+* `GITHUB_CLIENT_ID`
+* `GITHUB_CLIENT_TOKEN`
 
+and the user and token must have the appropriate permissions in this repository.
 
 [Node.js]: https://nodejs.org/en/
 [http-api]: docs/http-api.md
@@ -118,3 +121,4 @@ Then following the steps to create the release on github.com
 [Consul]: https://www.consul.io/
 [Amazon S3]: https://aws.amazon.com/s3/
 [gsg]: ./docs/getting-started/
+[github.com]: https://github.com

--- a/Rakefile
+++ b/Rakefile
@@ -40,11 +40,11 @@ def repo
 end
 
 def target_version
-  ::File.read(::File.join(@base_dir, '.nvmrc')).strip()
+  ::File.read(::File.join(base_dir, '.nvmrc')).strip.delete('v')
 end
 
 def max_version
-   target_version.split('.').first.to_f + 1
+  target_version.split('.').first.to_f + 1
 end
 
 def install_dir

--- a/Rakefile
+++ b/Rakefile
@@ -103,8 +103,7 @@ task :release => [:install, :shrinkwrap, :pack] do
   release = github_client.create_release(
     github_repo,
     "v#{version}",
-    :name => "v#{version}",
-    :draft => true
+    :name => "v#{version}", :draft => true
   )
 
   [

--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,15 @@ require 'mkmf'
 require 'aws-sdk'
 require 'logger'
 require 'rake/clean'
+require 'octokit'
 
 include FileUtils
 
+CLIENT_ID = ENV['GITHUB_CLIENT_ID']
+CLIENT_TOKEN = ENV['GITHUB_CLIENT_TOKEN']
+
 def package_json
- @package_json ||= JSON.parse(File.read('package.json'))
+  @package_json ||= JSON.parse(File.read('package.json'))
 end
 
 def version
@@ -31,6 +35,10 @@ def homepage
   package_json['homepage']
 end
 
+def repo
+  package_json['repository']['url'].sub('.git', '')
+end
+
 def target_version
   ::File.read(::File.join(@base_dir, '.nvmrc')).strip()
 end
@@ -51,6 +59,20 @@ def base_dir
   @base_dir ||= File.dirname(File.expand_path(__FILE__))
 end
 
+def pkg_dir
+  ::File.join(base_dir, 'pkg')
+end
+
+def github_client
+  @client unless @client.nil?
+  @client = Octokit::Client.new(:client_id => CLIENT_ID, :access_token => CLIENT_TOKEN)
+end
+
+def github_repo
+  @repo unless @repo.nil?
+  @repo = Octokit::Repository.from_url(repo)
+end
+
 task :install do
   sh 'npm install --production'
 end
@@ -69,6 +91,31 @@ task :release => [:install, :shrinkwrap, :pack] do
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
   puts 'Make sure you add release notes!'
+
+  cp ::File.join(base_dir, "#{name}-#{version}.tgz"), pkg_dir
+
+  begin
+    latest_release = github_client.latest_release(github_repo)
+  rescue Octokit::NotFound
+    latest_release = OpenStruct.new(name: 'master')
+  end
+
+  release = github_client.create_release(
+    github_repo,
+    "v#{version}",
+    :name => "v#{version}",
+    :draft => true
+  )
+
+  [
+    ::File.join(pkg_dir, "#{name}-#{version}.tgz"),
+    ::File.join(pkg_dir, "#{name}-#{version}_amd64.deb")
+  ].each do |f|
+    github_client.upload_asset(release.url, f)
+  end
+  puts "Draft release created at #{release.html_url}. Make sure you add release notes!"
+  compare_url = "#{github_repo.url}/compare/#{latest_release.name}...#{release.name}"
+  puts "You can find a diff between this release and the previous one here: #{compare_url}"
 end
 
 task :package_dirs do
@@ -85,7 +132,7 @@ end
 
 
 task :chdir_pkg => [:package_dirs] do
-  cd ::File.join(base_dir, 'pkg')
+  cd pkg_dir
 end
 
 task :deb => [:chdir_pkg, :propsd_source] do


### PR DESCRIPTION
This PR repurposes the `:release` task to create a new Github release. Running this task requires proper repository permissions or else the task will fail.