### PR TITLE
Fix: Faster Tokend integration tests

### DIFF
--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -14,6 +14,6 @@ Config.defaults({
   tokend: {
     host: '127.0.0.1',
     port: 4500,
-    interval: 100
+    interval: 10
   }
 });

--- a/test/tokend-transformer.js
+++ b/test/tokend-transformer.js
@@ -9,7 +9,7 @@ const Properties = require('../lib/properties');
 const Source = require('./lib/stub/source');
 
 // Speed up testing by shortening the time we wait for properties to build.
-Properties.BUILD_HOLD_DOWN = 100;
+Properties.BUILD_HOLD_DOWN = 10;
 
 describe('TokendTransformer', function () {
   let _transformer = null;


### PR DESCRIPTION
This speeds up the polling intervals for the Tokend integration tests so they run faster. We're seeing [timeout issues for some tests in Travis CI](https://travis-ci.org/rapid7/propsd/builds/164662716).