### PR TITLE
Rakefile Fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -136,6 +136,8 @@ end
 
 task :deb => [:chdir_pkg, :propsd_source] do
   command = [
+    'bundle',
+    'exec',
     'fpm',
     '--deb-no-default-config-files',
     "--depends \"nodejs >= #{target_version}\"",
@@ -148,7 +150,7 @@ task :deb => [:chdir_pkg, :propsd_source] do
     "-n \"#{name}\"",
     "-v #{version}",
     'opt/'
-    ].join(' ')
+  ].join(' ')
   sh command
   mkdir 'copy_to_s3'
   deb = Dir["#{name}_#{version}_*.deb"].first


### PR DESCRIPTION
This PR prefixes the fpm command with `bundle exec` to resolve issue with tasks being run using an old version of bundler.