### PR TITLE
Separate cookbook and build gem dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ node_modules
 .idea/
 
 cookbook/metadata.json
+
+# Build artifacts
+*.tar.gz
+*.tgz
+npm-shrinkwrap.json

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,7 @@ source 'https://rubygems.org'
 gem 'aws-sdk', '~> 2.2'
 gem 'fpm', '~> 1.4'
 gem 'octokit', '~> 4.0'
-gem 'builderator', '~> 1.0'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end


### PR DESCRIPTION
This PR defines a `:cookbook` group so we can use the `--without` flag when we want to `bundle install` and not have to wait forever for `dep-selector-libgecode` to install.