### PR TITLE
Make Rakefile great again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ node_modules
 .idea/
 
 cookbook/metadata.json
+
+# Build artifacts
+*.tar.gz
+*.tgz
+npm-shrinkwrap.json

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,7 @@ source 'https://rubygems.org'
 gem 'aws-sdk', '~> 2.2'
 gem 'fpm', '~> 1.4'
 gem 'octokit', '~> 4.0'
-gem 'builderator', '~> 1.0'
+
+group :cookbook do
+  gem 'builderator', '~> 1.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
+gem 'rake', '~> 10.5'
 gem 'aws-sdk', '~> 2.2'
-gem 'fpm', '~> 1.4'
+gem 'fpm', '~> 1.6'
 gem 'octokit', '~> 4.0'
 
 group :cookbook do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       faraday_middleware (~> 0.10.0)
       ignorefile
       thor (~> 0.19.0)
-    cabin (0.8.1)
+    cabin (0.9.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     celluloid-io (0.16.2)
@@ -98,9 +98,8 @@ GEM
       uuidtools (~> 2.1)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
-    clamp (0.6.5)
+    clamp (1.0.1)
     cleanroom (1.0.0)
-    corefines (1.9.0)
     dep-selector-libgecode (1.3.1)
     dep_selector (1.0.4)
       dep-selector-libgecode (~> 1.0)
@@ -114,16 +113,16 @@ GEM
     ffi (1.9.14)
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
-    fpm (1.5.0)
+    fpm (1.6.1)
       archive-tar-minitar
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
       childprocess
-      clamp (~> 0.6)
-      corefines (~> 1.9)
+      clamp (~> 1.0.0)
       ffi
       json (>= 1.7.7)
+      pleaserun (~> 0.0.24)
       ruby-xz
     fuzzyurl (0.9.0)
     hashie (3.4.4)
@@ -132,6 +131,7 @@ GEM
     httpclient (2.7.2)
     ignorefile (1.1.0)
     iniparse (1.4.2)
+    insist (1.0.0)
     io-like (0.3.0)
     ipaddress (0.8.3)
     jmespath (1.3.1)
@@ -149,6 +149,7 @@ GEM
     molinillo (0.4.5)
     multi_json (1.12.1)
     multipart-post (2.0.0)
+    mustache (0.99.8)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -175,9 +176,16 @@ GEM
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
+    pleaserun (0.0.24)
+      cabin (> 0)
+      clamp
+      insist
+      mustache (= 0.99.8)
+      stud
     plist (3.2.0)
     proxifier (1.0.3)
     rack (1.6.4)
+    rake (10.5.0)
     retryable (2.0.4)
     ridley (4.6.1)
       addressable
@@ -237,6 +245,7 @@ GEM
       net-ssh (>= 2.7, < 4.0)
       net-telnet
       sfl
+    stud (0.0.22)
     syslog-logger (1.6.8)
     systemu (2.6.5)
     thor (0.19.1)
@@ -254,8 +263,9 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk (~> 2.2)
   builderator (~> 1.0)
-  fpm (~> 1.4)
+  fpm (~> 1.6)
   octokit (~> 4.0)
+  rake (~> 10.5)
 
 BUNDLED WITH
    1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -123,19 +123,18 @@ task :package_dirs do
   mkdir_p ::File.join(base_dir, config_dir)
 end
 
-task :propsd_source => [:install] do
+task :source => [:install] do
   ['bin/', 'lib/', 'node_modules/', 'LICENSE', 'package.json'].each do |src|
     cp_r ::File.join(base_dir, src), ::File.join(base_dir, install_dir)
   end
   cp ::File.join(base_dir, 'config', 'defaults.json'), ::File.join(base_dir, config_dir)
 end
 
-
 task :chdir_pkg => [:package_dirs] do
   cd pkg_dir
 end
 
-task :deb => [:chdir_pkg, :propsd_source] do
+task :deb => [:chdir_pkg, :source] do
   command = [
     'bundle',
     'exec',

--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,8 @@ task :deb => [:chdir_pkg, :source] do
   sh command
 end
 
-task :upload_packages => [:deb] do
+task :upload_packages do
+  cd pkg_dir
   mkdir 'copy_to_s3'
   deb = Dir["#{name}_#{version}_*.deb"].first
   cp deb, 'copy_to_s3/'
@@ -137,7 +138,7 @@ task :upload_packages => [:deb] do
 end
 
 desc "Release #{name} and prepare to create a release on github.com"
-task :release => [:package] do
+task :release do
   puts
   puts "Create a new #{version} release on github.com and upload the #{name} tarball"
   puts 'You can find directions here: https://github.com/blog/1547-release-your-software'
@@ -178,3 +179,4 @@ CLEAN.include '**/.DS_Store'
 CLEAN.include 'node_modules/'
 
 task :default => [:clean, :package, :release]
+task :upload => [:clean, :package, :upload_packages]


### PR DESCRIPTION
This PR makes Rakefile tasks more consistent across the Spectre services. It was branched off of [gem-groups](https://github.com/rapid7/propsd/tree/gem-groups) but while it could be merged now, we should wait until #204 is merged just to make sure the intent of both pull requests is respected.