### PR TITLE
Adding support for Ubuntu 16.04 via systemd service support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,11 @@ node_modules
 cookbook/metadata.json
 
 # Build artifacts
+Berksfile
+Berksfile.lock
 *.tar.gz
 *.tgz
+.ruby-gemset
 npm-shrinkwrap.json
+cookbook/.kitchen/
+cookbook/.kitchen.local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,8 @@ gem 'mime-types', '~> 3.1'
 
 group :cookbook do
   gem 'builderator', '~> 1.0'
+  gem 'test-kitchen'
+  gem 'kitchen-docker'
+  gem 'kitchen-vagrant'
+  gem 'berkshelf', '~> 4.3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'mime-types', '~> 3.1'
 group :cookbook do
   gem 'builderator', '~> 1.0'
   gem 'test-kitchen'
-  gem 'kitchen-docker'
   gem 'kitchen-vagrant'
   gem 'berkshelf', '~> 4.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     archive-tar-minitar (0.5.2)
     arr-pm (0.0.10)
       cabin (> 0)
+    artifactory (2.5.0)
     aws-sdk (2.5.6)
       aws-sdk-resources (= 2.5.6)
     aws-sdk-core (2.5.6)
@@ -136,6 +137,10 @@ GEM
     ipaddress (0.8.3)
     jmespath (1.3.1)
     json (2.0.2)
+    kitchen-docker (2.6.0)
+      test-kitchen (>= 1.0.0)
+    kitchen-vagrant (0.20.0)
+      test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -147,8 +152,14 @@ GEM
       mixlib-log
     mixlib-cli (1.7.0)
     mixlib-config (2.2.2)
+    mixlib-install (2.1.5)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
+      thor
     mixlib-log (1.7.1)
     mixlib-shellout (2.2.7)
+    mixlib-versioning (1.1.0)
     molinillo (0.4.5)
     multi_json (1.12.1)
     multipart-post (2.0.0)
@@ -230,6 +241,7 @@ GEM
     ruby-xz (0.2.3)
       ffi (~> 1.9)
       io-like (~> 0.3)
+    safe_yaml (1.0.4)
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
@@ -251,6 +263,14 @@ GEM
     stud (0.0.22)
     syslog-logger (1.6.8)
     systemu (2.6.5)
+    test-kitchen (1.13.2)
+      mixlib-install (>= 1.2, < 3.0)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 4.0)
+      net-ssh-gateway (~> 1.2.0)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
     thor (0.19.1)
     timers (4.0.4)
       hitimes
@@ -265,11 +285,15 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk (~> 2.2)
+  berkshelf (~> 4.3)
   builderator (~> 1.0)
   fpm (~> 1.6)
+  kitchen-docker
+  kitchen-vagrant
   mime-types (~> 3.1)
   octokit (~> 4.0)
   rake (~> 10.5)
+  test-kitchen
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,8 +137,6 @@ GEM
     ipaddress (0.8.3)
     jmespath (1.3.1)
     json (2.0.2)
-    kitchen-docker (2.6.0)
-      test-kitchen (>= 1.0.0)
     kitchen-vagrant (0.20.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
@@ -288,7 +286,6 @@ DEPENDENCIES
   berkshelf (~> 4.3)
   builderator (~> 1.0)
   fpm (~> 1.6)
-  kitchen-docker
   kitchen-vagrant
   mime-types (~> 3.1)
   octokit (~> 4.0)

--- a/cookbook/.kitchen.yml
+++ b/cookbook/.kitchen.yml
@@ -1,0 +1,20 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[propsd::default]
+    attributes:
+      propsd:
+        config:
+          index:
+            bucket: 'some.bucket.name.that.does.not.exist.com'

--- a/cookbook/templates/default/systemd.service.erb
+++ b/cookbook/templates/default/systemd.service.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=<%= @description %>
+
+[Service]
+ExecStart=<%= ([@executable] + @flags).join(' ') %>
+<% unless @user.nil? %>User=<%= @user %><% end %>
+<% unless @group.nil? %>Group=<%= @group %><% end %>
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Currently this cookbook does not support systems that depend on systemd to start services.  

This change adds support for systemd.