### PR TITLE
Removed upstart script creation notifying service restart.

### DIFF
--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -96,8 +96,6 @@ template service_script_path do
       "-c #{node['propsd']['paths']['configuration']}"
     ]
   )
-
-  notifies :restart, 'service[propsd]' if node['propsd']['enable']
 end
 
 directory 'propsd-configuration-directory' do


### PR DESCRIPTION
This PR resolves a bug where enabling a previously disabled upstart service causes chef to modify the template per this diff:

```diff
#start on (local-filesystems and net-device-up IFACE!=lo)
---
start on (local-filesystems and net-device-up IFACE!=lo)
```

This restart was causing client services to fail when attempting to access Propsd.