### PR TITLE
Update node installation method

### DIFF
--- a/Buildfile
+++ b/Buildfile
@@ -7,6 +7,10 @@ cookbook.depends 'propsd' do |propsd|
   propsd.path './cookbook'
 end
 
-profile :default do |test|
+profile :default do |default|
+  default.chef.run_list ['propsd::nodejs', 'propsd::default']
+end
+
+profile :test do |test|
   test.chef.run_list 'propsd::test'
 end

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -11,7 +11,7 @@ maintainer_email 'coreservices@rapid7.com'
 issues_url package_dot_json['bugs']['url']
 source_url package_dot_json['homepage']
 
-license package_dot_json.fetch('license', 'MIT License, 2016')
+license package_dot_json.fetch('license', 'MIT License, 2017')
 long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -15,5 +15,4 @@ license package_dot_json.fetch('license', 'MIT License, 2016')
 long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 
-depends 'apt'
 depends 'ohai', '~> 4.2'

--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -15,4 +15,5 @@ license package_dot_json.fetch('license', 'MIT License, 2016')
 long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 
+depends 'nodejs'
 depends 'ohai', '~> 4.2'

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: propsd
 # Recipe:: default
 #
-# Copyright (C) 2016 Rapid7 LLC.
+# Copyright (C) 2017 Rapid7 LLC.
 #
 # Distributed under terms of the MIT License. All rights not explicitly granted
 # in the MIT license are reserved. See the included LICENSE file for more details.

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -8,23 +8,6 @@
 # in the MIT license are reserved. See the included LICENSE file for more details.
 #
 
-#######################
-## Install NodeJS 4.x
-#
-# This should be moved into a shared cookbook
-##
-include_recipe 'apt::default'
-
-apt_repository 'nodejs-4x' do
-  uri 'https://deb.nodesource.com/node_4.x'
-  distribution node['lsb']['codename']
-  components ['main']
-  key 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key'
-end
-
-package 'nodejs'
-#######################
-
 node.default['propsd']['version'] = cookbook_version
 
 group node['propsd']['group'] do

--- a/cookbook/recipes/nodejs.rb
+++ b/cookbook/recipes/nodejs.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook Name:: propsd
+# Recipe:: nodejs
+#
+# Copyright (C) 2017 Rapid7 LLC.
+#
+# Distributed under terms of the MIT License. All rights not explicitly granted
+# in the MIT license are reserved. See the included LICENSE file for more details.
+#
+
+node.default['nodejs']['version'] = '4.8.2'
+node.default['nodejs']['binary']['checksum'] = '4d4a37f980bb2770c44d7123864650d0823bae696d7db09d9ed83028cab32fd3'
+
+include_recipe 'nodejs::nodejs_from_binary'

--- a/cookbook/recipes/ohai_plugin.rb
+++ b/cookbook/recipes/ohai_plugin.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: propsd
 # Recipe:: ohai_plugin
 #
-# Copyright (C) 2016 Rapid7 LLC.
+# Copyright (C) 2017 Rapid7 LLC.
 #
 # Distributed under terms of the MIT License. All rights not explicitly granted
 # in the MIT license are reserved. See the included LICENSE file for more details.

--- a/cookbook/recipes/test.rb
+++ b/cookbook/recipes/test.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: propsd
 # Recipe:: test
 #
-# Copyright (C) 2016 Rapid7 LLC.
+# Copyright (C) 2017 Rapid7 LLC.
 #
 # Distributed under terms of the MIT License. All rights not explicitly granted
 # in the MIT license are reserved. See the included LICENSE file for more details.


### PR DESCRIPTION
This PR moves away from installing Nodejs from the NodeSource repository because they don't provide earlier versions preferring, instead, to install from binary.