### PR TITLE
Feature: metadata source gets ASG info

### DIFF
--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -99,6 +99,8 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
           p = new Promise((resolve, reject) => {
             (new Aws.AutoScaling({region})).describeAutoScalingInstances({InstanceIds: [instanceId]}, (err, d) => {
               if (err) {
+                Log.log('ERROR', err);
+
                 return reject(err);
               }
               resolve(d);

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -87,24 +87,59 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
           return callback(err);
         }
 
-        // Detect change by hashing the fetched data
-        const hash = Crypto.createHash('sha1');
-        const paths = Object.keys(data);
+        let p = Promise.resolve(data);
 
-        Log.log('DEBUG', `Source/Metadata: Fetched ${paths.length} paths from the ec2-metadata service`, this.status());
+        // Grab the ASG from the instance-id
+        const instanceId = data['meta-data/instance-id'];
+        const az = data['meta-data/placement/availability-zone'];
 
-        paths.sort().forEach((key) => {
-          hash.update(`${key}:${data[key]}`);
-        });
+        if (instanceId && az) {
+          const region = az.slice(0, -1);
 
-        const signature = hash.digest('base64');
+          p = new Promise((resolve, reject) => {
+            (new Aws.AutoScaling({region})).describeAutoScalingInstances({InstanceIds: [instanceId]}, (err, d) => {
+              if (err) {
+                return reject(err);
+              }
+              resolve(d);
+            });
+          }).then((d) => {
+            const asg = d.AutoScalingInstances.map((instance) => instance.AutoScalingGroupName);
 
-        if (this._state === signature) {
-          return callback(null, Source.NO_UPDATE);
+            // No reason it should be longer than 1 but worth a check
+            if (asg.length > 1) {
+              Log.log('WARN', `Instance id ${instanceId} is in multiple auto-scaling groups`, asg);
+            }
+
+            // Check to see if an instance is actually part of an ASG
+            if (asg.length !== 0) {
+              data['auto-scaling-group'] = asg[0];
+            }
+
+            return data;
+          }).catch(() => data);
         }
 
-        this._state = signature;
-        callback(null, data);
+        p.then((data) => {
+          // Detect change by hashing the fetched data
+          const hash = Crypto.createHash('sha1');
+          const paths = Object.keys(data);
+
+          Log.log('DEBUG', `Source/Metadata: Fetched ${paths.length} paths from the ec2-metadata service`, this.status());
+
+          paths.sort().forEach((key) => {
+            hash.update(`${key}:${data[key]}`);
+          });
+
+          const signature = hash.digest('base64');
+
+          if (this._state === signature) {
+            return callback(null, Source.NO_UPDATE);
+          }
+
+          this._state = signature;
+          callback(null, data);
+        });
       }
     );
   }

--- a/lib/source/metadata/parser.js
+++ b/lib/source/metadata/parser.js
@@ -154,5 +154,6 @@ Parser.mappings = {
     });
 
     properties['vpc-id'] = metadata[Path.join(path, mac, 'vpc-id')];
-  }
+  },
+  'auto-scaling-group': atBasename
 };


### PR DESCRIPTION
This PR adds functionality to the `Metadata` source to retrieve information about the instance's auto-scaling group. This resolves #126.