### PR TITLE
Support {{ instance:iam-role }} for indexing

### DIFF
--- a/lib/source/metadata/parser.js
+++ b/lib/source/metadata/parser.js
@@ -116,6 +116,7 @@ Parser.mappings = {
       return;
     }
 
+    properties['iam-role'] = Path.basename(roles[0]);
     const credentials = JSON.parse(metadata[roles[0]]);
 
     if (!properties.credentials) {

--- a/test/data/s3/index.json
+++ b/test/data/s3/index.json
@@ -23,6 +23,13 @@
       }
     },
     {
+      "name": "iam-role",
+      "type": "s3",
+      "parameters": {
+        "path": "role/{{ instance:iam-role }}.json"
+      }
+    },
+    {
       "name": "consul",
       "type": "consul"
     }

--- a/test/data/s3/role/fake-fake.json
+++ b/test/data/s3/role/fake-fake.json
@@ -1,0 +1,6 @@
+{
+  "version": 1.0,
+  "properties": {
+    "only.set.on.fake-fake": true
+  }
+}

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -35,6 +35,7 @@ describe('Metadata source plugin', function _() {
     // Currently used in our Index object.
     expect(parser.properties.account).to.be.a('string');
     expect(parser.properties.region).to.be.a('string');
+    expect(parser.properties['iam-role']).to.eq('fake-fake');
     expect(parser.properties['vpc-id']).to.be.a('string');
     expect(parser.properties['instance-id']).to.be.a('string');
 
@@ -96,6 +97,7 @@ describe('Metadata source plugin', function _() {
       expect(source.properties.account).to.be.a('string');
       expect(source.properties.region).to.be.a('string');
       expect(source.properties['vpc-id']).to.be.a('string');
+      expect(source.properties['iam-role']).to.eq('fake-fake');
       expect(source.properties['instance-id']).to.be.a('string');
 
       expect(source.properties.identity).to.be.an('object');


### PR DESCRIPTION
Context: One of our services is going to start consuming from different queues/buckets when given "role" of "on demand" instead of the default role. This lines up fairly closely with the instance profile/role since we want to only grant access based on those.

We can use the instance profile/role for separating services.

Instance Tags would be nice but this is very straight forward first step.