### PR TITLE
Fix: Consul source should not be loaded by default

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -21,7 +21,6 @@ const Logger = require('../lib/logger');
 
 const Properties = require('../lib/properties');
 const Sources = require('../lib/sources');
-const Consul = require('../lib/source/consul');
 const Metadata = require('../lib/source/metadata');
 const Tags = require('../lib/source/tags');
 const S3 = require('../lib/source/s3');
@@ -57,7 +56,6 @@ const properties = new Properties();
 const sources = new Sources(properties);
 
 // Add metadata and some statics
-properties.dynamic(new Consul('consul', Config.get('consul')), 'consul');
 properties.dynamic(new Metadata(Config.get('metadata')), 'instance');
 properties.dynamic(new Tags(Config.get('metadata')), 'instance:tags');
 properties.static(Config.get('properties'));

--- a/lib/source/consul.js
+++ b/lib/source/consul.js
@@ -24,9 +24,9 @@ class Consul extends Source.Polling(Parser) { // eslint-disable-line new-cap
    */
   constructor(name, opts) {
     const options = Object.assign({
-      host: Consul.DEFAULT_ADDRESS,
-      port: Consul.DEFAULT_PORT,
-      secure: false
+      host: Config.get('consul:host'),
+      port: Config.get('consul:port'),
+      secure: Config.get('consul:secure')
     }, opts);
 
     super(name, options);
@@ -79,8 +79,5 @@ class Consul extends Source.Polling(Parser) { // eslint-disable-line new-cap
     });
   }
 }
-
-Consul.DEFAULT_ADDRESS = '127.0.0.1';
-Consul.DEFAULT_PORT = 8500; // eslint-disable-line rapid7/static-magic-numbers
 
 module.exports = Consul;

--- a/lib/source/consul/parser.js
+++ b/lib/source/consul/parser.js
@@ -41,7 +41,8 @@ class Parser {
       };
     });
 
-    this.properties = properties;
+    // This is required in order to continue name-spacing consul properties
+    this.properties.consul = properties;
   }
 }
 

--- a/lib/sources.js
+++ b/lib/sources.js
@@ -185,7 +185,8 @@ class Sources extends EventEmitter {
 
 // Registered Source providers
 Sources.providers = {
-  s3: require('./source/s3')
+  s3: require('./source/s3'),
+  consul: require('./source/consul')
 };
 
 // Update hold-down timeout

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -78,18 +78,18 @@ function makeServer(propsUnderTest) {
   return app.listen(testServerPort);
 }
 
-describe('Conqueso API v1', () => {
+describe('Conqueso API v1', function() {
   let server = null;
 
-  beforeEach(() => {
+  beforeEach(function() {
     server = makeServer(conquesoProperties);
   });
 
-  afterEach((done) => {
+  afterEach(function(done) {
     server.close(done);
   });
 
-  it('acknowledges GET requests', (done) => {
+  it('acknowledges GET requests', function(done) {
     request(server)
       .get('/v1/conqueso/api/roles')
       .set('Accept', 'text/plain')
@@ -97,42 +97,42 @@ describe('Conqueso API v1', () => {
       .expect(HTTP_OK, javaProperties, done);
   });
 
-  it('acknowledges POST requests', (done) => {
+  it('acknowledges POST requests', function(done) {
     request(server)
       .post('/v1/conqueso/api/roles/search/properties')
       .send(conquesoProperties)
       .expect(HTTP_OK, '', done);
   });
 
-  it('acknowledges PUT requests', (done) => {
+  it('acknowledges PUT requests', function(done) {
     request(server)
       .put('/v1/conqueso/api/roles/search/properties')
       .send(conquesoProperties)
       .expect(HTTP_OK, '', done);
   });
 
-  it('acknowledges OPTIONS requests', (done) => {
+  it('acknowledges OPTIONS requests', function(done) {
     request(server)
       .options('/v1/conqueso')
       .expect('Allow', 'GET,POST,PUT,OPTIONS')
       .expect(HTTP_OK, '', done);
   });
 
-  it('rejects DELETE requests', (done) => {
+  it('rejects DELETE requests', function(done) {
     request(server)
       .delete('/v1/conqueso')
       .expect('Allow', 'GET,POST,PUT,OPTIONS')
       .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
   });
 
-  it('rejects TRACE requests', (done) => {
+  it('rejects TRACE requests', function(done) {
     request(server)
       .trace('/v1/conqueso')
       .expect('Allow', 'GET,POST,PUT,OPTIONS')
       .expect(HTTP_METHOD_NOT_ALLOWED, '', done);
   });
 
-  it('rejects HEAD requests', (done) => {
+  it('rejects HEAD requests', function(done) {
     request(server)
       .head('/v1/conqueso')
       .expect('Allow', 'GET,POST,PUT,OPTIONS')
@@ -141,13 +141,13 @@ describe('Conqueso API v1', () => {
 });
 
 // This is split out into a separate 'describe' group because of the way express binds ports
-describe('Conqueso API v1', () => {
+describe('Conqueso API v1', function() {
   let server;
 
-  before(() => {
+  before(function() {
     server = makeServer(nestedProperties);
   });
-  it('emits properly flattened data', (done) => {
+  it('emits properly flattened data', function(done) {
     request(server)
       .get('/v1/conqueso/api/roles')
       .set('Accept', 'text/plain')
@@ -155,7 +155,7 @@ describe('Conqueso API v1', () => {
       .expect(HTTP_OK, nestedJavaProperties, done);
   });
 
-  it('retrieves a specific property if it exists', (done) => {
+  it('retrieves a specific property if it exists', function(done) {
     request(server)
       .get('/v1/conqueso/api/roles/global/properties/food.name')
       .set('Accept', 'text/plain')
@@ -163,7 +163,7 @@ describe('Conqueso API v1', () => {
       .expect(HTTP_OK, 'tacos', done);
   });
 
-  it('returns no data if a specific property does not exist', (done) => {
+  it('returns no data if a specific property does not exist', function(done) {
     request(server)
       .get('/v1/conqueso/api/roles/global/properties/food.gluten')
       .set('Accept', 'text/plain')
@@ -171,36 +171,34 @@ describe('Conqueso API v1', () => {
       .expect(HTTP_OK, '', done);
   });
 
-  after((done) => {
+  after(function(done) {
     server.close(done);
   });
 });
 
-describe('Conqueso API v1', () => {
+describe('Conqueso API v1', function() {
   let consul = null,
       server = null;
 
-  beforeEach((done) => {
+  beforeEach(function(done) {
     consul = new Consul('consul');
     consul.client = ConsulStub;
 
-    consul.initialize().then(() => {
+    consul.initialize().then(function() {
       server = makeServer({
-        properties: {
-          consul: consul.properties
-        }
+        properties: consul.properties
       });
 
       done();
     });
   });
 
-  afterEach((done) => {
+  afterEach(function(done) {
     consul.shutdown();
     server.close(done);
   });
 
-  it('formats IP addresses for Consul services', (done) => {
+  it('formats IP addresses for Consul services', function(done) {
     const expected = [
       'conqueso.postgresql.ips=10.0.0.2',
       'conqueso.redis.ips=10.0.0.1',
@@ -217,7 +215,7 @@ describe('Conqueso API v1', () => {
       .expect(HTTP_OK, done);
   });
 
-  it('removes reserved "instance" keyword from properties', (done) => {
+  it('removes reserved "instance" keyword from properties', function(done) {
     server.close();
 
     server = makeServer({

--- a/test/consul.js
+++ b/test/consul.js
@@ -8,7 +8,7 @@ const Consul = require('../lib/source/consul');
 const expect = require('chai').expect;
 
 describe('Consul', function() {
-  it('instantiates a Consul Source with defaults', () => {
+  it('instantiates a Consul Source with defaults', function() {
     const consul = new Consul('test');
 
     // See https://github.com/silas/node-papi/blob/master/lib/client.js#L71
@@ -19,7 +19,7 @@ describe('Consul', function() {
     expect(consul.properties).to.be.empty;
   });
 
-  it('overrides defaults from constructor options', () => {
+  it('overrides defaults from constructor options', function() {
     const consul = new Consul('test', {
       host: '1.1.1.1',
       port: 1234,

--- a/test/consul.js
+++ b/test/consul.js
@@ -7,7 +7,7 @@ const Consul = require('../lib/source/consul');
 
 const expect = require('chai').expect;
 
-describe('Consul', function _() {
+describe('Consul', function() {
   it('instantiates a Consul Source with defaults', () => {
     const consul = new Consul('test');
 
@@ -31,15 +31,15 @@ describe('Consul', function _() {
     expect(consul.client._opts.secure).to.equal(true);
   });
 
-  it('sets up properties on initialize', function __(done) {
+  it('sets up properties on initialize', function() {
     const consul = new Consul('test');
 
     consul.client = Stub;
 
-    consul.initialize()
-      .then(() => {
-        expect(consul.state).to.equal(Consul.RUNNING);
-        expect(consul.properties).to.eql({
+    return consul.initialize().then(() => {
+      expect(consul.state).to.equal(Consul.RUNNING);
+      expect(consul.properties).to.eql({
+        consul: {
           consul: {
             cluster: 'consul',
             addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3']
@@ -52,14 +52,12 @@ describe('Consul', function _() {
             cluster: 'postgresql',
             addresses: ['10.0.0.2']
           }
-        });
-
-        done();
-      })
-      .catch(done);
+        }
+      });
+    });
   });
 
-  it('handles errors safely', function ___(done) {
+  it('handles errors safely', function() {
     const consul = new Consul('test');
 
     consul.client = Stub;
@@ -67,12 +65,9 @@ describe('Consul', function _() {
       callback(new Error('This is a test error!'), null);
     };
 
-    consul.initialize()
-      .then(() => {
-        expect(consul.state).to.equal(Consul.ERROR);
-        expect(consul.properties).to.eql({});
-        done();
-      })
-      .catch(done);
+    return consul.initialize().then(() => {
+      expect(consul.state).to.equal(Consul.ERROR);
+      expect(consul.properties).to.eql({});
+    });
   });
 });

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -15,5 +15,10 @@ Config.defaults({
     host: '127.0.0.1',
     port: 4500,
     interval: 10
+  },
+  consul: {
+    host: '127.0.0.1',
+    port: 8500,
+    secure: false
   }
 });


### PR DESCRIPTION
This PR removes the Consul source from being loaded by default as a `dynamic` layer. Instead, it is loaded as a regular source. In order to maintain backwards compatibility, the set of Consul properties is namespaced in the same way that it was before this change.

Resolves #223.