### PR TITLE
Cookbook: Guard symlink resource

### DIFF
--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -17,3 +17,4 @@ version package_dot_json.fetch('version', '0.0.1')
 
 depends 'nodejs'
 depends 'ohai', '~> 4.2'
+depends 'ark', '~> 3.0.0'

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -37,12 +37,15 @@ package 'propsd' do
   source resources('remote_file[propsd]').path
   provider Chef::Provider::Package::Dpkg
   version node['propsd']['version']
+
+  notifies :create, "link[#{node['propsd']['paths']['directory']}]", :immediately
 end
 
 ## Symlink the version dir to the specified propsd directory
 link node['propsd']['paths']['directory'] do
   to version_dir
 
+  action :nothing
   notifies :restart, 'service[propsd]' if node['propsd']['enable']
 end
 


### PR DESCRIPTION
This PR adds a notification guard to the symlink resource so nothing gets linked unless the service is installed.