### PR TITLE
Fix: empty properties are persisted as `null`.

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -155,7 +155,7 @@ class Properties extends EventEmitter {
         if (!layer.namespace) {
           return merge(properties, layer.properties);
         }
-        properties[layer.namespace] = layer.properties;
+        properties[layer.namespace] = merge(properties[layer.namespace], layer.properties);
 
         return properties;
       }, {});

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -151,32 +151,27 @@ class Properties extends EventEmitter {
     this._building = setTimeout(() => {
       // Merge layers into their own object. This can be consumed as an input by
       // template renderers.
-      const persistent = this.layers.reduce((p, layer) => {
+      const persistent = this.layers.reduce((properties, layer) => {
         if (!layer.namespace) {
-          return p.mergeDeep(Immutable.fromJS(layer.properties));
+          return merge(properties, layer.properties);
         }
-        const layerProps = Immutable.Map(layer.properties);
+        properties[layer.namespace] = layer.properties;
 
-        return p.setIn(layer.namespace.split(':'), layerProps);
-      }, new Immutable.Map());
+        return properties;
+      }, {});
 
-      const properties = this.active.sources.reduce((p, source) => {
-        const props = Immutable.fromJS(source.properties);
+      const properties = merge(
+        this.active.sources.reduce((properties, source) => merge(properties, source.properties), {}),
+        persistent
+      );
 
-        return p.mergeDeep(props);
-      }, new Immutable.Map())
-          .mergeDeep(persistent)
-          // Null properties should be filtered out entirely
-          .filter((p) => !!p);
+      this.tokendTransformer.transform(properties).then((transformedProperties) => {
+        this.persistent = persistent;
+        this.properties = Immutable.Map(properties).mergeDeep(transformedProperties).toJS();
 
-      this.tokendTransformer.transform(properties.toJS())
-          .then((transformedProperties) => {
-            this.persistent = persistent.toJS();
-            this.properties = Immutable.Map(properties).mergeDeep(transformedProperties).toJS();
-
-            this.emit('build', this.properties);
-            delete this._building;
-          });
+        this.emit('build', this.properties);
+        delete this._building;
+      });
     }, Properties.BUILD_HOLD_DOWN);
 
     return built;

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -124,7 +124,10 @@ class Properties extends EventEmitter {
         const props = Immutable.fromJS(source.properties);
 
         return p.mergeDeep(props);
-      }, new Immutable.Map()).mergeDeep(persistent);
+      }, new Immutable.Map())
+          .mergeDeep(persistent)
+          // Null properties should be filtered out entirely
+          .filter((p) => !!p);
 
       this.tokendTransformer.transform(properties.toJS())
           .then((transformedProperties) => {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -5,6 +5,46 @@ const View = require('./properties/view');
 const TokendTransformer = require('./transformers/tokend');
 const Immutable = require('immutable');
 
+/* eslint-disable eqeqeq */
+/**
+ * Deep-merge one Object into another. Do _not_ deep merge anything that isn't explicitly
+ * a first-order instance of Object.
+ *
+ * @param  {Object} destination   The destination of the merge operation. This object is mutated
+ * @param  {Object} source        The source that properties are merged from
+ * @return {Object}               The destination object
+ */
+const merge = (destination, source) => {
+  // Ensure that the destination value is an Object. `== null ` covers both null and undefined
+  const dest = (destination == null ||
+  Object.getPrototypeOf(destination) !== Object.prototype) ? {} : destination;
+
+  // Only merge source if it's an Object. `== null ` covers both null and undefined
+  if (source == null || Object.getPrototypeOf(source) !== Object.prototype) {
+    return dest;
+  }
+
+  Object.keys(source).forEach((key) => {
+    // Ignore null and undefined source values. `== null` covers both
+    if (source[key] == null) {
+      return;
+    }
+
+    // Is this an Object (but not something that inherits Object)?
+    if (Object.getPrototypeOf(source[key]) === Object.prototype) {
+      // Recursively merge source Object into destination
+      dest[key] = merge(dest[key], source[key]);
+
+      return;
+    }
+
+    dest[key] = source[key];
+  });
+
+  return dest;
+};
+/* eslint-enable eqeqeq */
+
 /**
  * A Properties instance manages multiple statically configured layers,
  * and an active View instance.
@@ -148,5 +188,6 @@ Properties.BUILD_HOLD_DOWN = 1000; // eslint-disable-line rapid7/static-magic-nu
 
 Properties.Layer = Layer;
 Properties.View = View;
+Properties.merge = merge;
 
 module.exports = Properties;

--- a/test/properties.js
+++ b/test/properties.js
@@ -125,6 +125,38 @@ describe('Properties', function() {
     properties.build();
   });
 
+  it('doesn\'t override values with properties that have null values', function(done) {
+    const properties = new Properties();
+    const stub = new Source.Stub();
+    const stub2 = new Source.Stub();
+
+    properties.static({
+      cruel: 'world',
+      leaving: null,
+      change: 'my-mind'
+    });
+
+    stub.properties = {
+      change: null
+    };
+
+    stub2.properties = {
+      cruel: null
+    };
+
+    properties.dynamic(stub);
+    properties.dynamic(stub2);
+
+    properties.once('build', (props) => {
+      expect(props.cruel).to.equal('world');
+      expect(props.leaving).to.be.an('undefined');
+      expect(props.change).to.equal('my-mind');
+      done();
+    });
+
+    properties.build();
+  });
+
   it('adds a dynamic layer and rebuilds on updates', function(done) {
     const stub = new Source.Stub();
 

--- a/test/properties.js
+++ b/test/properties.js
@@ -157,6 +157,30 @@ describe('Properties', function() {
     properties.build();
   });
 
+  it('merges namespaced layers correctly', function(done) {
+    const properties = new Properties();
+
+    properties.static({
+      cruel: 'world',
+      leaving: null,
+      change: 'my-mind'
+    }, 'goodbye');
+
+    properties.static({
+      foo: 'bar'
+    }, 'goodbye');
+
+    properties.once('build', (props) => {
+      expect(props.goodbye.cruel).to.equal('world');
+      expect(props.goodbye.leaving).to.be.an('undefined');
+      expect(props.goodbye.change).to.equal('my-mind');
+      expect(props.goodbye.foo).to.equal('bar');
+      done();
+    });
+
+    properties.build();
+  });
+
   it('adds a dynamic layer and rebuilds on updates', function(done) {
     const stub = new Source.Stub();
 

--- a/test/properties.js
+++ b/test/properties.js
@@ -257,3 +257,133 @@ describe('Properties', function() {
     }).catch(done);
   });
 });
+
+
+describe('Merge', function() {
+  it('merges one object into another', function() {
+    const a = {};
+    const b = {
+      a: 1, b: 2, c: {
+        a: [],
+        b: new Date(0)
+      }
+    };
+
+    const c = Properties.merge(a, b);
+
+    expect(a).to.equal(c);
+    expect(c).to.deep.equal(b);
+  });
+
+  it('merges objects recursively', function() {
+    const a = {
+      a: 2, c: {
+        d: 42
+      },
+      e: []
+    };
+    const b = {
+      a: 1, b: 2, c: {
+        a: [],
+        b: new Date(0)
+      }
+    };
+
+    const c = Properties.merge(a, b);
+
+    expect(a).to.equal(c);
+    expect(c).to.deep.equal({
+      a: 1, b: 2, c: {
+        a: [],
+        b: new Date(0),
+        d: 42
+      },
+      e: []
+    });
+  });
+
+  it('instantiates a new object for destination when null or undefined are passed', function() {
+    const a = null;
+    const b = {a: 1};
+
+    const c = Properties.merge(a, b);
+
+    expect(c).to.not.equal(a);
+    expect(c).to.not.equal(b);
+    expect(c).to.deep.equal({a: 1});
+  });
+
+  it('avoids merging source when null or undefined are passed', function() {
+    const a = {a: 1};
+    const b = null;
+
+    const c = Properties.merge(a, b);
+
+    expect(c).to.equal(a);
+    expect(c).to.deep.equal({a: 1});
+  });
+
+  it('avoids merging keys with null or undefined values', function() {
+    const a = {a: 0};
+    const b = {
+      z: 1,
+      n: null,
+      u: undefined
+    };
+
+    const c = Properties.merge(a, b);
+
+    expect(c).to.equal(a);
+    expect(c).to.deep.equal({
+      a: 0,
+      z: 1
+    });
+  });
+
+  it('always returns an Object', function() {
+    const a = [];
+    const b = null;
+
+    const c = Properties.merge(a, b);
+
+    expect(c).to.not.equal(a);
+    expect(c).to.not.equal(b);
+    expect(c).to.be.instanceOf(Object);
+    expect(c).to.deep.equal({});
+  });
+
+  it('does not attempt to merge values that aren\'t direct descendants of Object', function() {
+    const a = {
+      a: 2, c: {
+        a: [1, 2, 3],
+        b: {a: 'foo'},
+        d: 42,
+        e: new Date(1),
+        f: []
+      },
+      e: []
+    };
+    const b = {
+      a: 1, b: 2, c: {
+        a: [],
+        b: new Date(0),
+        e: 'bar',
+        f: {a: 123}
+      }
+    };
+
+    const c = Properties.merge(a, b);
+
+    expect(a).to.equal(c);
+    expect(c).to.deep.equal({
+      a: 1, b: 2, c: {
+        a: [],
+        b: new Date(0),
+        d: 42,
+        e: 'bar',
+        f: {a: 123}
+      },
+      e: []
+    });
+  });
+});

--- a/test/properties.js
+++ b/test/properties.js
@@ -97,6 +97,34 @@ describe('Properties', function() {
     properties.build();
   });
 
+  it('removes properties that have null values', function(done) {
+    const properties = new Properties();
+
+    properties.static({
+      cruel: 'world',
+      leaving: null,
+      change: 'my-mind'
+    }, 'goodbye');
+
+    const stub = new Source.Stub();
+
+    stub.properties = {
+      stubby: null
+    };
+
+    properties.dynamic(stub);
+
+    properties.once('build', (props) => {
+      expect(props.goodbye.cruel).to.equal('world');
+      expect(props.goodbye.leaving).to.be.an('undefined');
+      expect(props.goodbye.change).to.equal('my-mind');
+      expect(props.stubby).to.be.an('undefined');
+      done();
+    });
+
+    properties.build();
+  });
+
   it('adds a dynamic layer and rebuilds on updates', function(done) {
     const stub = new Source.Stub();
 


### PR DESCRIPTION
This PR fixes a regression introduced in 4e925e4 where empty properties were assigned null rather than removed from the properties object entirely.