### PR TITLE
Fix: Metadata source requests too much data

### DIFF
--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -81,30 +81,37 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
         if (instanceId && az) {
           const region = az.slice(0, -1);
 
-          p = new Promise((resolve, reject) => {
-            (new Aws.AutoScaling({region})).describeAutoScalingInstances({InstanceIds: [instanceId]}, (err, d) => {
-              if (err) {
-                Log.log('ERROR', err);
+          if (!this.parser.properties['auto-scaling-group']) {
+            Log.log('DEBUG', 'Retrieving auto-scaling-group data');
+            p = new Promise((resolve, reject) => {
+              (new Aws.AutoScaling({region})).describeAutoScalingInstances({InstanceIds: [instanceId]}, (err, d) => {
+                if (err) {
+                  Log.log('ERROR', err);
 
-                return reject(err);
+                  return reject(err);
+                }
+                resolve(d);
+              });
+            }).then((d) => {
+              const asg = d.AutoScalingInstances.map((instance) => instance.AutoScalingGroupName);
+
+              // No reason it should be longer than 1 but worth a check
+              if (asg.length > 1) {
+                Log.log('WARN', `Instance id ${instanceId} is in multiple auto-scaling groups`, asg);
               }
-              resolve(d);
-            });
-          }).then((d) => {
-            const asg = d.AutoScalingInstances.map((instance) => instance.AutoScalingGroupName);
 
-            // No reason it should be longer than 1 but worth a check
-            if (asg.length > 1) {
-              Log.log('WARN', `Instance id ${instanceId} is in multiple auto-scaling groups`, asg);
-            }
+              // Check to see if an instance is actually part of an ASG
+              if (asg.length !== 0) {
+                data['auto-scaling-group'] = asg[0];
+              }
 
-            // Check to see if an instance is actually part of an ASG
-            if (asg.length !== 0) {
-              data['auto-scaling-group'] = asg[0];
-            }
-
-            return data;
-          }).catch(() => data);
+              return data;
+            }).catch(() => data);
+          } else {
+            Log.log('DEBUG', 'Using cached auto-scaling-group data.');
+            data['auto-scaling-group'] = this.parser.properties['auto-scaling-group'];
+            p = Promise.resolve(data);
+          }
         }
 
         p.then((data) => {


### PR DESCRIPTION
This PR fixes an issue where ASG retrieval is done every time the metadata source refreshes instead of caching the data.