### PR TITLE
Update dev metadata port number

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -5,7 +5,7 @@
     "path": "index.json"
   },
   "metadata": {
-    "host": "127.0.0.1:8900"
+    "host": "127.0.0.1:8080"
   },
   "log": {
     "level": "info",


### PR DESCRIPTION
Port 8900 produces
```
"ERROR: Aws-sdk returned the following error during the metadata service request to /latest/meta-data/placement/availability-zone: {"code":"ECONNREFUSED","errno":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8900}"

```

Changed to "8080" corrects the error.