### PR TITLE
Make tags source tuneable

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -57,7 +57,7 @@ const sources = new Sources(properties);
 
 // Add metadata and some statics
 properties.dynamic(new Metadata(Config.get('metadata')), 'instance');
-properties.dynamic(new Tags(Config.get('metadata')), 'instance:tags');
+properties.dynamic(new Tags(Config.get('tags')), 'instance:tags');
 properties.static(Config.get('properties'));
 
 // Create the Index source

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -25,5 +25,8 @@
   "metadata": {
     "host": "169.254.169.254",
     "interval": 30000
+  },
+  "tags": {
+    "interval": 300000
   }
 }

--- a/lib/source/metadata.js
+++ b/lib/source/metadata.js
@@ -109,7 +109,7 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
             }).catch(() => data);
           } else {
             Log.log('DEBUG', 'Using cached auto-scaling-group data.');
-            data['auto-scaling-group'] = this.parser.properties['auto-scaling-group'];
+            data['auto-scaling-group'] = this.properties['auto-scaling-group'];
             p = Promise.resolve(data);
           }
         }


### PR DESCRIPTION
This PR creates a separate config object for the `Tags` source so we can make it poll less frequently.