### PR TITLE
Fix tag source is not nested

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -4,6 +4,7 @@ const Layer = require('./properties/layer');
 const View = require('./properties/view');
 const TokendTransformer = require('./transformers/tokend');
 const Immutable = require('immutable');
+const isPlainObject = require('lodash.isplainobject');
 
 /* eslint-disable eqeqeq */
 /**
@@ -16,11 +17,10 @@ const Immutable = require('immutable');
  */
 const merge = (destination, source) => {
   // Ensure that the destination value is an Object. `== null ` covers both null and undefined
-  const dest = (destination == null ||
-  Object.getPrototypeOf(destination) !== Object.prototype) ? {} : destination;
+  const dest = isPlainObject(destination) ? destination : {};
 
   // Only merge source if it's an Object. `== null ` covers both null and undefined
-  if (source == null || Object.getPrototypeOf(source) !== Object.prototype) {
+  if (!isPlainObject(source)) {
     return dest;
   }
 

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -45,6 +45,28 @@ const merge = (destination, source) => {
 };
 /* eslint-enable eqeqeq */
 
+const recusiveNamespaceMerge = (object, namespaceArray, value) => {
+  const nextNamespace = namespaceArray.shift();
+
+  if (namespaceArray.length) {
+    if (isPlainObject(object[nextNamespace]) || typeof object[nextNamespace] === 'undefined') {
+      return recusiveNamespaceMerge(object[nextNamespace] || {}, namespaceArray, value);
+    }
+
+    return object;
+  }
+  if (object != null) { // eslint-disable-line eqeqeq
+    object[nextNamespace] = merge(object[nextNamespace], value);
+  } else {
+    object = {
+      [nextNamespace]: value
+    };
+  }
+
+
+  return object;
+};
+
 /**
  * A Properties instance manages multiple statically configured layers,
  * and an active View instance.
@@ -155,7 +177,15 @@ class Properties extends EventEmitter {
         if (!layer.namespace) {
           return merge(properties, layer.properties);
         }
-        properties[layer.namespace] = merge(properties[layer.namespace], layer.properties);
+
+        let namespace = layer.namespace.split(':');
+        const namespaceRoot = namespace.shift();
+
+        if (namespace.length > 0) {
+          properties[namespaceRoot] = recusiveNamespaceMerge(properties[namespaceRoot], namespace, layer.properties);
+        } else {
+          properties[namespaceRoot] = merge(properties[namespaceRoot], layer.properties);
+        }
 
         return properties;
       }, {});

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -16,10 +16,10 @@ const isPlainObject = require('lodash.isplainobject');
  * @return {Object}               The destination object
  */
 const merge = (destination, source) => {
-  // Ensure that the destination value is an Object. `== null ` covers both null and undefined
+  // Ensure that the destination value is an Object.
   const dest = isPlainObject(destination) ? destination : {};
 
-  // Only merge source if it's an Object. `== null ` covers both null and undefined
+  // Only merge source if it's an Object.
   if (!isPlainObject(source)) {
     return dest;
   }

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -45,26 +45,26 @@ const merge = (destination, source) => {
 };
 /* eslint-enable eqeqeq */
 
-const recusiveNamespaceMerge = (object, namespaceArray, value) => {
+/**
+ * Recursively traverses a layer namespace and sets the value at the corresponding place in the object
+ * @param {Object} destination The destination of the merge operation.
+ * @param {Array<String>} namespaceArray An array of keys (namespaces) to traverse
+ * @param {Object} source The source that properties are merged from
+ * @return {Object}
+ */
+const recusiveNamespaceMerge = (destination, namespaceArray, source) => {
   const nextNamespace = namespaceArray.shift();
+  const dest = isPlainObject(destination) ? destination : {};
 
   if (namespaceArray.length) {
-    if (isPlainObject(object[nextNamespace]) || typeof object[nextNamespace] === 'undefined') {
-      return recusiveNamespaceMerge(object[nextNamespace] || {}, namespaceArray, value);
-    }
+    dest[nextNamespace] = recusiveNamespaceMerge(dest[nextNamespace] || {}, namespaceArray, source);
 
-    return object;
-  }
-  if (object != null) { // eslint-disable-line eqeqeq
-    object[nextNamespace] = merge(object[nextNamespace], value);
-  } else {
-    object = {
-      [nextNamespace]: value
-    };
+    return dest;
   }
 
+  dest[nextNamespace] = merge(dest[nextNamespace], source);
 
-  return object;
+  return dest;
 };
 
 /**

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -57,7 +57,7 @@ const recusiveNamespaceMerge = (destination, namespaceArray, source) => {
   const dest = isPlainObject(destination) ? destination : {};
 
   if (namespaceArray.length) {
-    dest[nextNamespace] = recusiveNamespaceMerge(dest[nextNamespace] || {}, namespaceArray, source);
+    dest[nextNamespace] = recusiveNamespaceMerge(dest[nextNamespace], namespaceArray, source);
 
     return dest;
   }

--- a/lib/source/tags.js
+++ b/lib/source/tags.js
@@ -25,15 +25,14 @@ class Tags extends Source.Polling(Parser) { // eslint-disable-line new-cap
    * @param {Object} opts
    */
   constructor(opts) {
-    // Inject defaults into options
-    const options = Object.assign({
+    super('ec2-tags', opts);
+
+    const metadataOptions = Object.assign({
       timeout: Metadata.DEFAULT_TIMEOUT,
       host: Metadata.DEFAULT_HOST
-    }, opts);
+    }, Config.get('metadata'), opts);
 
-    super('ec2-tags', options);
-
-    this._metadata = new MetadataClient(options);
+    this._metadata = new MetadataClient(metadataOptions);
   }
 
   /**

--- a/lib/transformers/tokend.js
+++ b/lib/transformers/tokend.js
@@ -14,7 +14,7 @@ const isPlainObject = require('lodash.isplainobject');
 function collectTransformables(properties, keyPath) {
   let results = [];
 
-  // Ensure we're walking an Object. `== null` covers both null and undefined.
+  // Ensure we're walking an Object.
   if (!isPlainObject(properties)) {
     return results;
   }
@@ -29,7 +29,7 @@ function collectTransformables(properties, keyPath) {
   Object.keys(properties).forEach((key) => {
     const value = properties[key];
 
-    // Don't walk anything that's not an Object. `!= null` covers both null and undefined.
+    // Don't walk anything that's not an Object.
     if (isPlainObject(value)) {
       results = results.concat(collectTransformables(value, keyPath.concat(key)));
     }

--- a/lib/transformers/tokend.js
+++ b/lib/transformers/tokend.js
@@ -2,6 +2,7 @@
 
 const TokendClient = require('./tokend-client');
 const Immutable = require('immutable');
+const isPlainObject = require('lodash.isplainobject');
 
 /**
  * Walk a properties object looking for transformable values
@@ -14,7 +15,7 @@ function collectTransformables(properties, keyPath) {
   let results = [];
 
   // Ensure we're walking an Object. `== null` covers both null and undefined.
-  if (properties == null || Object.getPrototypeOf(properties) !== Object.prototype) { // eslint-disable-line eqeqeq
+  if (!isPlainObject(properties)) {
     return results;
   }
 
@@ -29,7 +30,7 @@ function collectTransformables(properties, keyPath) {
     const value = properties[key];
 
     // Don't walk anything that's not an Object. `!= null` covers both null and undefined.
-    if (value != null && Object.getPrototypeOf(value) === Object.prototype) { // eslint-disable-line eqeqeq
+    if (isPlainObject(value)) {
       results = results.concat(collectTransformables(value, keyPath.concat(key)));
     }
   });

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "express-winston": "~1.3.0",
     "flat": "~2.0.0",
     "immutable": "~3.8.1",
+    "lodash.isplainobject": "^4.0.6",
     "nconf": "~0.8.4",
     "winston": "~2.1.1",
     "yargs": "~4.1.0"

--- a/test/properties.js
+++ b/test/properties.js
@@ -181,9 +181,10 @@ describe('Properties', function() {
     properties.build();
   });
 
-  it('properly nests namespaces', function(done) {
+  it.only('properly nests namespaces', function(done) {
     const properties = new Properties();
     const stub = new Source.Stub();
+    const stub2 = new Source.Stub();
 
     stub.properties = {
       cruel: 'world',
@@ -191,13 +192,24 @@ describe('Properties', function() {
       change: 'my-mind'
     };
 
-    properties.dynamic(stub, 'goodbye:friends');
+    stub2.properties = {
+      foo: 'bar',
+      baz: 3,
+      quiz: true
+    };
 
+    properties.dynamic(stub, 'goodbye:friends');
+    properties.dynamic(stub2, 'this:is:really:deeply:nested');
 
     properties.once('build', (props) => {
       expect(props.goodbye.friends).to.be.instanceOf(Object);
       expect(props.goodbye.friends.change).to.equal('my-mind');
       expect(props.goodbye.friends.cruel).to.equal('world');
+
+      expect(props.this.is.really.deeply.nested).to.be.instanceOf(Object);
+      expect(props.this.is.really.deeply.nested.foo).to.equal('bar');
+      expect(props.this.is.really.deeply.nested.baz).to.equal(3);
+      expect(props.this.is.really.deeply.nested.quiz).to.be.true;
       done();
     });
 

--- a/test/properties.js
+++ b/test/properties.js
@@ -181,7 +181,7 @@ describe('Properties', function() {
     properties.build();
   });
 
-  it.only('properly nests namespaces', function(done) {
+  it('properly nests namespaces', function(done) {
     const properties = new Properties();
     const stub = new Source.Stub();
     const stub2 = new Source.Stub();

--- a/test/properties.js
+++ b/test/properties.js
@@ -181,6 +181,60 @@ describe('Properties', function() {
     properties.build();
   });
 
+  it('properly nests namespaces', function(done) {
+    const properties = new Properties();
+    const stub = new Source.Stub();
+
+    stub.properties = {
+      cruel: 'world',
+      leaving: null,
+      change: 'my-mind'
+    };
+
+    properties.dynamic(stub, 'goodbye:friends');
+
+
+    properties.once('build', (props) => {
+      expect(props.goodbye.friends).to.be.instanceOf(Object);
+      expect(props.goodbye.friends.change).to.equal('my-mind');
+      expect(props.goodbye.friends.cruel).to.equal('world');
+      done();
+    });
+
+    properties.build();
+  });
+
+  it('properly nests namespaces for multiple layers', function(done) {
+    const properties = new Properties();
+    const stub = new Source.Stub();
+    const stub2 = new Source.Stub();
+
+    stub.properties = {
+      cruel: 'world',
+      leaving: null,
+      change: 'my-mind'
+    };
+
+    stub2.properties = {
+      foo: 'bar',
+      baz: 3
+    };
+
+    properties.dynamic(stub, 'goodbye');
+    properties.dynamic(stub2, 'goodbye:friends');
+
+    properties.once('build', (props) => {
+      expect(props.goodbye.change).to.equal('my-mind');
+      expect(props.goodbye.cruel).to.equal('world');
+      expect(props.goodbye.friends).to.be.instanceOf(Object);
+      expect(props.goodbye.friends.baz).to.equal(3);
+      expect(props.goodbye.friends.foo).to.equal('bar');
+      done();
+    });
+
+    properties.build();
+  });
+
   it('adds a dynamic layer and rebuilds on updates', function(done) {
     const stub = new Source.Stub();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,6 +1634,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"


### PR DESCRIPTION
This PR resolves an issue where the `Tag` source would not nest its data in the `instance` object but instead create a new object with key `instance:tags`.