### PR TITLE
Bug: TokendTransformer caching

### DIFF
--- a/src/lib/control/v1/conqueso.js
+++ b/src/lib/control/v1/conqueso.js
@@ -84,15 +84,18 @@ function Conqueso(app, storage) {
   // Conqueso compatible APIs are defined before the generic catch all route.
   app.get('/v1/conqueso/api/roles/:role/properties/:property', (req, res) => {
     const property = req.params.property;
-    const properties = makeConquesoProperties(storage.properties);
 
-    res.set('Content-Type', 'text/plain');
+    storage.properties.then((props) => {
+      const properties = makeConquesoProperties(props);
 
-    if (property && (properties.hasOwnProperty(property))) {
-      res.end(String(properties[property]));
-    } else {
-      res.end();
-    }
+      res.set('Content-Type', 'text/plain');
+
+      if (property && (properties.hasOwnProperty(property))) {
+        res.end(String(properties[property]));
+      } else {
+        res.end();
+      }
+    });
   });
 
   // Handle any other requests by returning all properites.
@@ -111,8 +114,10 @@ function Conqueso(app, storage) {
   }
 
   route.get((req, res) => {
-    res.set('Content-Type', 'text/plain');
-    res.end(makeJavaProperties(makeConquesoProperties(storage.properties)));
+    storage.properties.then((props) => {
+      res.set('Content-Type', 'text/plain');
+      res.end(makeJavaProperties(makeConquesoProperties(props)));
+    });
   });
 
   // Express defaults to using the GET route for HEAD requests.

--- a/src/lib/control/v1/properties.js
+++ b/src/lib/control/v1/properties.js
@@ -11,23 +11,26 @@ const STATUS_CODES = require('../../util/status-codes');
  */
 exports.attach = function attach(app, storage) {
   app.get('/v1/properties/:property*', function handler(req, res, next) {
-    const properties = storage.properties;
-    const prop = req.params.property;
+    storage.properties.then((properties) => {
+      const prop = req.params.property;
 
-    Log.log('INFO', 'Params: ', req.params);
+      Log.log('INFO', 'Params: ', req.params);
 
-    if (!properties[prop]) {
-      return next(new Error(`Property ${prop} not found`));
-    }
+      if (!properties[prop]) {
+        return next(new Error(`Property ${prop} not found`));
+      }
 
-    const value = properties[prop];
-    const extra = req.params[0].split('/').filter(Boolean);
+      const value = properties[prop];
+      const extra = req.params[0].split('/').filter(Boolean);
 
-    res.json(getNestedProperty(value, Array.from(extra)));
+      res.json(getNestedProperty(value, Array.from(extra)));
+    });
   });
 
   app.get('/v1/properties*', function handler(req, res) {
-    res.json(storage.properties);
+    storage.properties.then((properties) => {
+      res.json(properties);
+    });
   });
 
   app.use('/v1/properties/:property*', (err, req, res, next) => { // eslint-disable-line no-unused-vars

--- a/src/lib/transformers/tokend-client.js
+++ b/src/lib/transformers/tokend-client.js
@@ -159,6 +159,32 @@ class TokendClient extends Source.Polling(TokendParser) {
   }
 
   /**
+   * Removes a request's Promise it from the specified pending request cache
+   * @param {string} type
+   * @param {string} id
+   */
+  clearCacheAtKey(type, id) {
+    let cache = null;
+
+    switch (type.toLowerCase()) {
+      case 'get':
+        cache = this._pendingGetRequests;
+        break;
+      case 'post':
+        cache = this._pendingPostRequests;
+        break;
+      default:
+        throw new Error(`A ${type} request does not map to an existing cache.`);
+    }
+
+    if (cache[id]) {
+      delete cache[id];
+    } else {
+      Log.log('DEBUG', `No data at ${id} in ${type} cache`);
+    }
+  }
+
+  /**
    * Implementation for getting a secret from Tokend
    *
    * @param {String} path - Path where the secret in Tokend can be found.

--- a/src/lib/transformers/tokend-client.js
+++ b/src/lib/transformers/tokend-client.js
@@ -159,7 +159,7 @@ class TokendClient extends Source.Polling(TokendParser) {
   }
 
   /**
-   * Removes a request's Promise it from the specified pending request cache
+   * Removes a request's fulfilled Promise from the specified pending request cache
    * @param {string} type
    * @param {string} id
    */

--- a/test/conqueso-api-v1.js
+++ b/test/conqueso-api-v1.js
@@ -20,13 +20,13 @@ const conquesoProperties = {
     'meta.property.1': 'songs you have never heard of',
     'meta.property.2': 'artisanal cream cheese'
   },
-  properties: {
+  properties: Promise.resolve({
     date: fixedDate,
     regex: fixedRegex,
     name: 'hipster-mode-enabled',
     value: true,
     type: 'BOOLEAN'
-  },
+  }),
   on() {}
 };
 
@@ -35,7 +35,7 @@ const nestedProperties = {
     'meta.property.1': 'songs you have never heard of',
     'meta.property.2': 'artisanal cream cheese'
   },
-  properties: {
+  properties: Promise.resolve({
     name: 'hipster-mode-enabled',
     value: true,
     type: 'BOOLEAN',
@@ -44,7 +44,7 @@ const nestedProperties = {
       value: true,
       type: 'BOOLEAN'
     }
-  },
+  }),
   on() {}
 };
 
@@ -186,7 +186,7 @@ describe('Conqueso API v1', function() {
 
     consul.initialize().then(function() {
       server = makeServer({
-        properties: consul.properties
+        properties: Promise.resolve(consul.properties)
       });
 
       done();
@@ -219,12 +219,12 @@ describe('Conqueso API v1', function() {
     server.close();
 
     server = makeServer({
-      properties: {
+      properties: Promise.resolve({
         instance: {
           food: 'tacos'
         },
         gluten: 'free'
-      },
+      }),
       on() {}
     });
 

--- a/test/properties.js
+++ b/test/properties.js
@@ -21,10 +21,11 @@ describe('Properties', function() {
     expect(properties.layers.length).to.equal(1);
 
     properties.once('build', (props) => {
-      expect(props).to.be.instanceOf(Object);
-      expect(props.hello).to.equal('world');
-
-      done();
+      expect(props).to.be.instanceOf(Promise);
+      props.then((p) => {
+        expect(p.hello).to.equal('world');
+        done();
+      });
     });
 
     properties.build();
@@ -89,9 +90,11 @@ describe('Properties', function() {
     }, 'goodbye');
 
     properties.once('build', (props) => {
-      expect(props.hello).to.equal('world');
-      expect(props.goodbye.cruel).to.equal('world');
-      done();
+      props.then((p) => {
+        expect(p.hello).to.equal('world');
+        expect(p.goodbye.cruel).to.equal('world');
+        done();
+      });
     });
 
     properties.build();
@@ -115,11 +118,13 @@ describe('Properties', function() {
     properties.dynamic(stub);
 
     properties.once('build', (props) => {
-      expect(props.goodbye.cruel).to.equal('world');
-      expect(props.goodbye.leaving).to.be.an('undefined');
-      expect(props.goodbye.change).to.equal('my-mind');
-      expect(props.stubby).to.be.an('undefined');
-      done();
+      props.then((p) => {
+        expect(p.goodbye.cruel).to.equal('world');
+        expect(p.goodbye.leaving).to.be.an('undefined');
+        expect(p.goodbye.change).to.equal('my-mind');
+        expect(p.stubby).to.be.an('undefined');
+        done();
+      });
     });
 
     properties.build();
@@ -148,10 +153,12 @@ describe('Properties', function() {
     properties.dynamic(stub2);
 
     properties.once('build', (props) => {
-      expect(props.cruel).to.equal('world');
-      expect(props.leaving).to.be.an('undefined');
-      expect(props.change).to.equal('my-mind');
-      done();
+      props.then((p) => {
+        expect(p.cruel).to.equal('world');
+        expect(p.leaving).to.be.an('undefined');
+        expect(p.change).to.equal('my-mind');
+        done();
+      });
     });
 
     properties.build();
@@ -171,11 +178,13 @@ describe('Properties', function() {
     }, 'goodbye');
 
     properties.once('build', (props) => {
-      expect(props.goodbye.cruel).to.equal('world');
-      expect(props.goodbye.leaving).to.be.an('undefined');
-      expect(props.goodbye.change).to.equal('my-mind');
-      expect(props.goodbye.foo).to.equal('bar');
-      done();
+      props.then((p) => {
+        expect(p.goodbye.cruel).to.equal('world');
+        expect(p.goodbye.leaving).to.be.an('undefined');
+        expect(p.goodbye.change).to.equal('my-mind');
+        expect(p.goodbye.foo).to.equal('bar');
+        done();
+      });
     });
 
     properties.build();
@@ -202,15 +211,17 @@ describe('Properties', function() {
     properties.dynamic(stub2, 'this:is:really:deeply:nested');
 
     properties.once('build', (props) => {
-      expect(props.goodbye.friends).to.be.instanceOf(Object);
-      expect(props.goodbye.friends.change).to.equal('my-mind');
-      expect(props.goodbye.friends.cruel).to.equal('world');
+      props.then((p) => {
+        expect(p.goodbye.friends).to.be.instanceOf(Object);
+        expect(p.goodbye.friends.change).to.equal('my-mind');
+        expect(p.goodbye.friends.cruel).to.equal('world');
 
-      expect(props.this.is.really.deeply.nested).to.be.instanceOf(Object);
-      expect(props.this.is.really.deeply.nested.foo).to.equal('bar');
-      expect(props.this.is.really.deeply.nested.baz).to.equal(3);
-      expect(props.this.is.really.deeply.nested.quiz).to.be.true;
-      done();
+        expect(p.this.is.really.deeply.nested).to.be.instanceOf(Object);
+        expect(p.this.is.really.deeply.nested.foo).to.equal('bar');
+        expect(p.this.is.really.deeply.nested.baz).to.equal(3);
+        expect(p.this.is.really.deeply.nested.quiz).to.be.true;
+        done();
+      });
     });
 
     properties.build();
@@ -236,12 +247,14 @@ describe('Properties', function() {
     properties.dynamic(stub2, 'goodbye:friends');
 
     properties.once('build', (props) => {
-      expect(props.goodbye.change).to.equal('my-mind');
-      expect(props.goodbye.cruel).to.equal('world');
-      expect(props.goodbye.friends).to.be.instanceOf(Object);
-      expect(props.goodbye.friends.baz).to.equal(3);
-      expect(props.goodbye.friends.foo).to.equal('bar');
-      done();
+      props.then((p) => {
+        expect(p.goodbye.change).to.equal('my-mind');
+        expect(p.goodbye.cruel).to.equal('world');
+        expect(p.goodbye.friends).to.be.instanceOf(Object);
+        expect(p.goodbye.friends.baz).to.equal(3);
+        expect(p.goodbye.friends.foo).to.equal('bar');
+        done();
+      });
     });
 
     properties.build();
@@ -258,10 +271,12 @@ describe('Properties', function() {
 
     properties.initialize().then(() => {
       properties.once('build', (props) => {
-        expect(props.hello).to.equal('world');
-        expect(props.goodbye.cruel).to.equal('world');
-        expect(props.stubby).to.equal('property!');
-        done();
+        props.then((p) => {
+          expect(p.hello).to.equal('world');
+          expect(p.goodbye.cruel).to.equal('world');
+          expect(p.stubby).to.equal('property!');
+          done();
+        });
       });
 
       stub.emit('update');
@@ -299,12 +314,14 @@ describe('Properties', function() {
 
     view.activate().then(() => {
       properties.once('build', (props) => {
-        expect(props.hello).to.equal('world');
-        expect(props.goodbye.cruel).to.equal('world');
-        expect(props.stubby).to.equal('property!');
-        expect(props.foo).to.equal('bar');
+        props.then((p) => {
+          expect(p.hello).to.equal('world');
+          expect(p.goodbye.cruel).to.equal('world');
+          expect(p.stubby).to.equal('property!');
+          expect(p.foo).to.equal('bar');
 
-        done();
+          done();
+        });
       });
 
       stub.emit('update');
@@ -321,14 +338,16 @@ describe('Properties', function() {
     const view = properties.view(sources);
 
     properties.once('build', (props) => {
-      expect(stub.state).to.equal(Source.WAITING);
+      props.then((p) => {
+        expect(stub.state).to.equal(Source.WAITING);
 
-      expect(props.hello).to.equal('world');
-      expect(props.goodbye.cruel).to.equal('world');
-      expect(props.stubby).to.equal('property!');
-      expect(props.foo).to.equal('bar');
+        expect(p.hello).to.equal('world');
+        expect(p.goodbye.cruel).to.equal('world');
+        expect(p.stubby).to.equal('property!');
+        expect(p.foo).to.equal('bar');
 
-      done();
+        done();
+      });
     });
 
     view.activate();
@@ -351,15 +370,17 @@ describe('Properties', function() {
     };
 
     properties.once('build', (props) => {
-      expect(props.hello).to.equal('world');
-      expect(props.goodbye.cruel).to.equal('world');
-      expect(props.stubby).to.equal('property!');
+      props.then((p) => {
+        expect(p.hello).to.equal('world');
+        expect(p.goodbye.cruel).to.equal('world');
+        expect(p.stubby).to.equal('property!');
 
-      // This specifically tests the hold-down behavior. If it didn't work,
-      // the first sources indexNumber (0) will be set on the first 'build'
-      // event instead
-      expect(props.indexNumber).to.equal(1);
-      done();
+        // This specifically tests the hold-down behavior. If it didn't work,
+        // the first sources indexNumber (0) will be set on the first 'build'
+        // event instead
+        expect(p.indexNumber).to.equal(1);
+        done();
+      });
     });
 
     sources.forEach((source, i) => {

--- a/test/tokend-transformer.js
+++ b/test/tokend-transformer.js
@@ -463,12 +463,14 @@ describe('Properties#build', function() {
     });
 
     _properties.once('build', (transformedProperties) => {
-      expect(transformedProperties).to.eql({
-        password: 'toor'
-      });
+      transformedProperties.then((p) => {
+        expect(p).to.eql({
+          password: 'toor'
+        });
 
-      tokend.done();
-      done();
+        tokend.done();
+        done();
+      });
     });
 
     _properties.build();
@@ -494,13 +496,15 @@ describe('Properties#build', function() {
 
     _properties.dynamic(stub);
 
-    _properties.once('build', (transformedProperties) => {
-      expect(transformedProperties).to.eql({
-        password: 'toor'
-      });
+    _properties.once('build', (props) => {
+      props.then((transformedProperties) => {
+        expect(transformedProperties).to.eql({
+          password: 'toor'
+        });
 
-      tokend.done();
-      done();
+        tokend.done();
+        done();
+      });
     });
 
     _properties.build();
@@ -541,13 +545,15 @@ describe('Properties#build', function() {
     _properties.dynamic(stub);
     _properties.dynamic(stub2);
 
-    _properties.once('build', (transformedProperties) => {
-      expect(transformedProperties).to.eql({
-        password: 'toor'
-      });
+    _properties.once('build', (props) => {
+      props.then((transformedProperties) => {
+        expect(transformedProperties).to.eql({
+          password: 'toor'
+        });
 
-      tokend.done();
-      done();
+        tokend.done();
+        done();
+      });
     });
 
     _properties.build();

--- a/test/tokend-transformer.js
+++ b/test/tokend-transformer.js
@@ -4,6 +4,7 @@ require('./lib/helpers');
 
 const expect = require('chai').expect;
 const nock = require('nock');
+const sinon = require('sinon');
 const TokendTransformer = require('../dist/lib/transformers/tokend');
 const Properties = require('../dist/lib/properties');
 const Source = require('./lib/stub/source');
@@ -422,6 +423,42 @@ describe('TokendTransformer', function() {
         password: null
       });
 
+      tokend.done();
+    });
+  });
+
+  it('removes a resolved or rejected entry from the pending cache when it has been fulfilled', function() {
+    const untransformedProperties = {
+      password: {
+        $tokend: {
+          type: 'kms',
+          resource: '/v1/kms/decrypt',
+          ciphertext: 'gbbe',
+          datakey: 'foobar'
+        }
+      }
+    };
+
+    const tokend = nock('http://127.0.0.1:4500')
+        .post('/v1/kms/decrypt', {
+          ciphertext: 'gbbe',
+          datakey: 'foobar'
+        })
+        .reply(200, {
+          plaintext: 'toor',
+          keyid: 'arn:aws:kms:region:account-id:key/key-id'
+        });
+
+    _transformer = new TokendTransformer();
+    sinon.spy(_transformer._client, 'clearCacheAtKey');
+
+    return _transformer.transform(untransformedProperties).then((transformedProperties) => {
+      expect(_transformer._client.clearCacheAtKey.calledOnce).to.be.true;
+      const call = _transformer._client.clearCacheAtKey.firstCall;
+
+      // KMS type makes POST requests
+      expect(call.args[0]).to.equal('POST');
+      expect(call.args[1]).to.equal(`${untransformedProperties.password.$tokend.resource}.KMS.${untransformedProperties.password.$tokend.ciphertext}`);
       tokend.done();
     });
   });


### PR DESCRIPTION
This bug fixes an issue where the `TokendTransformer` caches request Promises and never attempts them again. Calls to `transform` continue to use the old `Promise` which has already been resolved or rejected.