### PR TITLE
Fix: Add Tokend caching

### DIFF
--- a/src/config/defaults.json
+++ b/src/config/defaults.json
@@ -20,7 +20,8 @@
   "tokend": {
     "host": "127.0.0.1",
     "port": 4500,
-    "interval": 300000
+    "interval": 300000,
+    "cacheTTL": 300000
   },
   "metadata": {
     "host": "169.254.169.254",

--- a/src/lib/properties.js
+++ b/src/lib/properties.js
@@ -83,7 +83,9 @@ class Properties extends EventEmitter {
     this.layers = [];
     this._properties = Immutable.Map();
     this.active = new View(this);
-    this.tokendTransformer = new TokendTransformer();
+    this.tokendTransformer = new TokendTransformer({
+      cacheTTL: Config.get('cacheTTL')
+    });
   }
 
   /**

--- a/src/lib/transformers/tokend.js
+++ b/src/lib/transformers/tokend.js
@@ -5,6 +5,8 @@ const Immutable = require('immutable');
 const isPlainObject = require('lodash.isplainobject');
 const crypto = require('crypto');
 
+const DEFAULT_CACHE_TTL = 300000;
+
 /**
  * Walk a properties object looking for transformable values
  *
@@ -48,8 +50,14 @@ class TokendTransformer {
    * @param {Object} options  See TokendClient for options
    */
   constructor(options) {
-    this._client = new TokendClient(options);
+    const opts = options || {};
+
+    this._client = new TokendClient(opts);
     this._cache = {};
+
+    setInterval(() => {
+      this._cache = {};
+    }, opts.cacheTTL || DEFAULT_CACHE_TTL);
   }
 
   /**

--- a/src/lib/transformers/tokend.js
+++ b/src/lib/transformers/tokend.js
@@ -60,22 +60,24 @@ class TokendTransformer {
     setImmediate(() => {
       this._cache = {};
 
-      this._expireCache(Math.random() * ((this._interval + 60000) - this._interval) + this._interval);
+      this._expireCache();
     });
   }
 
   /**
    * Expires the cache and calculates a new timeout for the next expiration time.
-   * @param {Number} interval
+   * @return {Number}
    * @private
    */
-  _expireCache(interval) {
+  _expireCache() {
     const i = Math.random() * ((this._interval + 60000) - this._interval) + this._interval;
 
     setTimeout(() => {
       this._cache = {};
-      this._expireCache(i);
-    }, interval);
+      this._expireCache();
+    }, i);
+
+    return i;
   }
 
   /**

--- a/src/lib/transformers/tokend.js
+++ b/src/lib/transformers/tokend.js
@@ -12,7 +12,7 @@ const DEFAULT_CACHE_TTL = 300000;
  *
  * @param {Object} properties  an object to search for transformable values
  * @param {Array} keyPath  accumulated path of keys where transformable value was found
- * @return {Array<Immutable.Map>} transformable data with injected key path
+ * @return {Array<Immutable.OrderedMap>} transformable data with injected key path
  */
 function collectTransformables(properties, keyPath) {
   let results = [];
@@ -26,7 +26,7 @@ function collectTransformables(properties, keyPath) {
   const keys = Object.keys(properties);
 
   if (keys.length === 1 && keys[0] === '$tokend') {
-    return results.concat(Immutable.Map(properties.$tokend).set('keyPath', keyPath));
+    return results.concat(Immutable.OrderedMap(properties.$tokend).set('keyPath', keyPath));
   }
 
   Object.keys(properties).forEach((key) => {

--- a/src/lib/transformers/tokend.js
+++ b/src/lib/transformers/tokend.js
@@ -55,9 +55,27 @@ class TokendTransformer {
     this._client = new TokendClient(opts);
     this._cache = {};
 
-    setInterval(() => {
+    this._interval = opts.cacheTTL || DEFAULT_CACHE_TTL;
+
+    setImmediate(() => {
       this._cache = {};
-    }, opts.cacheTTL || DEFAULT_CACHE_TTL);
+
+      this._expireCache(Math.random() * ((this._interval + 60000) - this._interval) + this._interval);
+    });
+  }
+
+  /**
+   * Expires the cache and calculates a new timeout for the next expiration time.
+   * @param {Number} interval
+   * @private
+   */
+  _expireCache(interval) {
+    const i = Math.random() * ((this._interval + 60000) - this._interval) + this._interval;
+
+    setTimeout(() => {
+      this._cache = {};
+      this._expireCache(i);
+    }, interval);
   }
 
   /**

--- a/test/tokend-transformer.js
+++ b/test/tokend-transformer.js
@@ -598,8 +598,8 @@ describe('TokendTransformer', function() {
     const spy = sinon.spy(_transformer, '_expireCache');
 
     clock.tick(900000);
-    spy.args.forEach((call) => {
-      expect(call[0]).to.be.within(cacheTTL, cacheTTL + 60000);
+    spy.returnValues.forEach((val) => {
+      expect(val).to.be.within(cacheTTL, cacheTTL + 60000);
     });
   });
 });

--- a/test/tokend-transformer.js
+++ b/test/tokend-transformer.js
@@ -452,7 +452,7 @@ describe('TokendTransformer', function() {
     _transformer = new TokendTransformer();
     sinon.spy(_transformer._client, 'clearCacheAtKey');
 
-    return _transformer.transform(untransformedProperties).then((transformedProperties) => {
+    return _transformer.transform(untransformedProperties).then(() => {
       expect(_transformer._client.clearCacheAtKey.calledOnce).to.be.true;
       const call = _transformer._client.clearCacheAtKey.firstCall;
 

--- a/test/tokend-transformer.js
+++ b/test/tokend-transformer.js
@@ -427,7 +427,7 @@ describe('TokendTransformer', function() {
     });
   });
 
-  it('removes a resolved or rejected entry from the pending cache when it has been fulfilled', function() {
+  it('removes a resolved or rejected entry from the client\'s pending cache when it has been fulfilled', function() {
     const untransformedProperties = {
       password: {
         $tokend: {

--- a/test/tokend-transformer.js
+++ b/test/tokend-transformer.js
@@ -580,7 +580,7 @@ describe('TokendTransformer', function() {
       expect(requestCount).to.equal(1);
       expect(Object.keys(_transformer._cache).length).to.equal(1);
     }).then(() => {
-      clock.tick(300001);
+      clock.tick(360001);
 
       return _transformer.transform(untransformedProperties);
     }).then(() => {
@@ -588,6 +588,18 @@ describe('TokendTransformer', function() {
       expect(Object.keys(_transformer._cache).length).to.equal(0);
 
       tokend.done();
+    });
+  });
+
+  it('varies the cache lifetime', function() {
+    const cacheTTL = 300000;
+
+    _transformer = new TokendTransformer({cacheTTL});
+    const spy = sinon.spy(_transformer, '_expireCache');
+
+    clock.tick(900000);
+    spy.args.forEach((call) => {
+      expect(call[0]).to.be.within(cacheTTL, cacheTTL + 60000);
     });
   });
 });


### PR DESCRIPTION
This PR caches responses from Tokend so we don't bust KMS API limits by doing decrypt operations  on every secret every time we hit the `/conqueso` or `/properties` endpoint.