### PR TITLE
Refactor metadata path traversal

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/rapid7/propsd#readme",
   "devDependencies": {
-    "aws-sdk-mock": "~1.2.0",
+    "aws-sdk-mock": "^1.7.0",
     "babel-cli": "^6.24.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
@@ -55,7 +55,7 @@
     "walk": "~2.3.9"
   },
   "dependencies": {
-    "aws-sdk": "~2.2.28",
+    "aws-sdk": "^2.215.1",
     "babel-runtime": "^6.23.0",
     "clone": "~1.0.2",
     "consul": "~0.23.0",

--- a/src/lib/source/metadata.js
+++ b/src/lib/source/metadata.js
@@ -58,10 +58,15 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
   /**
    * Fetch implementation for EC2 Metadata
    * @param {Function} callback
+   * @returns {void}
    * @private
    */
   _fetch(callback) {
-    const {error, values} = Util.traverse(this.version, Parser.paths, (path, cb) => this.service.request(path, cb));
+    const {error, values} = Util.traverse(
+      this.version,
+      Parser.paths,
+      (path, cb) => this.service.request(path, cb)
+    );
 
     if (error) {
       return callback(error);
@@ -78,26 +83,9 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
 
       if (!this.parser.properties['auto-scaling-group']) {
         Log.log('DEBUG', 'Retrieving auto-scaling-group data');
-        p = new Promise((resolve, reject) => {
-          (new Aws.AutoScaling({region})).describeAutoScalingInstances({InstanceIds: [instanceId]}, (err, d) => {
-            if (err) {
-              Log.log('ERROR', err);
-
-              return reject(err);
-            }
-            resolve(d);
-          });
-        }).then((d) => {
-          const asg = d.AutoScalingInstances.map((instance) => instance.AutoScalingGroupName);
-
-          // No reason it should be longer than 1 but worth a check
-          if (asg.length > 1) {
-            Log.log('WARN', `Instance id ${instanceId} is in multiple auto-scaling groups`, asg);
-          }
-
-          // Check to see if an instance is actually part of an ASG
-          if (asg.length !== 0) {
-            values['auto-scaling-group'] = asg[0];
+        p = this._getAsgName(region, instanceId).then((asg) => {
+          if (asg) {
+            values['auto-scaling-group'] = asg;
           }
 
           return values;
@@ -110,17 +98,9 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
     }
 
     p.then((data) => {
-      // Detect change by hashing the fetched data
-      const hash = Crypto.createHash('sha1');
-      const paths = Object.keys(data);
-
-      Log.log('DEBUG', `Source/Metadata: Fetched ${paths.length} paths from the ec2-metadata service`, this.status());
-
-      paths.sort().forEach((key) => {
-        hash.update(`${key}:${data[key]}`);
-      });
-
-      const signature = hash.digest('base64');
+      Log.log('DEBUG', `Source/Metadata: Fetched ${Object.keys(data).length} paths` +
+        `from the ec2-metadata service`, this.status());
+      const signature = this._hashMetaData(data);
 
       if (this._state === signature) {
         return callback(null, Source.NO_UPDATE);
@@ -129,6 +109,52 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
       this._state = signature;
       callback(null, data);
     });
+  }
+
+  /**
+   * Get the ASG name
+   *
+   * @param {String} region The region the instance is in
+   * @param {String} instanceId The instance Id
+   * @returns {Promise}
+   */
+  _getAsgName(region, instanceId) {
+    return (new Aws.AutoScaling({region})).describeAutoScalingInstances({InstanceIds: [instanceId]})
+      .promise()
+      .then((d) => {
+        const asg = d.AutoScalingInstances.map((instance) => instance.AutoScalingGroupName);
+
+        // No reason it should be longer than 1 but worth a check
+        if (asg.length > 1) {
+          Log.log('WARN', `Instance id ${instanceId} is in multiple auto-scaling groups`, asg);
+        }
+
+        // Check to see if an instance is actually part of an ASG
+        if (asg.length !== 0) {
+          return asg[0];
+        }
+
+        Log.log('INFO', `Instance ${instanceId} is not part of an autoscaling group.`);
+
+        return null;
+      });
+  }
+
+  /**
+   * Hash data from the ec2metadata endpoint
+   *
+   * @param {Object} data Data retrieved from the ec2metadata endpoint
+   * @returns {String}
+   */
+  _hashMetaData(data) {
+    const hash = Crypto.createHash('sha1');
+    const paths = Object.keys(data);
+
+    paths.sort().forEach((key) => {
+      hash.update(`${key}:${data[key]}`);
+    });
+
+    return hash.digest('base64');
   }
 }
 

--- a/src/lib/source/metadata.js
+++ b/src/lib/source/metadata.js
@@ -81,8 +81,12 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
     if (instanceId && az) {
       const region = az.slice(0, -1);
 
+      // Check whether we've cached the ASG name so we don't continue
+      // to try to grab it. We assume an instance isn't going to change
+      // ASG.
       if (!this.parser.properties['auto-scaling-group']) {
         Log.log('DEBUG', 'Retrieving auto-scaling-group data');
+
         p = this._getAsgName(region, instanceId).then((asg) => {
           if (asg) {
             values['auto-scaling-group'] = asg;
@@ -92,6 +96,7 @@ class Metadata extends Source.Polling(Parser) { // eslint-disable-line new-cap
         }).catch(() => values);
       } else {
         Log.log('DEBUG', 'Using cached auto-scaling-group data.');
+
         values['auto-scaling-group'] = this.properties['auto-scaling-group'];
         p = Promise.resolve(values);
       }

--- a/test/bin/get-metadata
+++ b/test/bin/get-metadata
@@ -19,7 +19,7 @@
 const AWS = require('aws-sdk');
 const FS = require('fs');
 const Path = require('path');
-const Util = require('../../lib/source/metadata/util');
+const Util = require('../../dist/lib/source/metadata/util');
 
 const metadata = new AWS.MetadataService({
   host: 'localhost:8080'
@@ -27,23 +27,20 @@ const metadata = new AWS.MetadataService({
 
 const paths = {};
 
-Util.traverse(
+const results = Util.traverse(
   'latest',
   ['/meta-data/', '/dynamic/'],
-
-  // Call `Metadata.request` for each path
   (path, cb) => metadata.request(path, (err, data) => {
-    if (err) { return cb(err); }
+    if (err) {
+      return cb(err);
+    }
 
-    // Store unparsed data from each path
     paths[path] = data;
-
     cb(null, data);
-  }),
+  }));
 
-  // Handle results of metadata tree traversal
-  (err) => {
-    if (err) { throw err; }
-    FS.writeFileSync(Path.resolve(__dirname, '../data/metadata-paths.json'), JSON.stringify(paths, null, 2));
-  }
-);
+if (results.error) {
+  throw results.error;
+}
+
+FS.writeFileSync(Path.resolve(__dirname, '../data/metadata-paths.json'), JSON.stringify(paths, null, 2));

--- a/test/bin/parse-matadata
+++ b/test/bin/parse-matadata
@@ -7,20 +7,19 @@
 
 const FS = require('fs');
 const Path = require('path');
-const Util = require('../../lib/source/metadata/util');
+const Util = require('../../dist/lib/source/metadata/util');
 
 const metadata = require('../data/metadata-paths.json');
 
-Util.traverse(
+const results = Util.traverse(
   'latest',
   ['/meta-data/', '/dynamic/'],
 
   // Call `Metadata.request` for each path
-  (path, cb) => cb(null, metadata[path]),
+  (path, cb) => cb(null, metadata[path]));
 
-  // Handle results of metadata tree traversal
-  (err, data) => {
-    if (err) { throw err; }
-    FS.writeFileSync(Path.resolve(__dirname, '../data/metadata-values.json'), JSON.stringify(data, null, 2));
-  }
-);
+if (results.error) {
+  throw results.error;
+}
+
+FS.writeFileSync(Path.resolve(__dirname, '../data/metadata-values.json'), JSON.stringify(results.values, null, 2));

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -10,11 +10,11 @@ const Metadata = require('../dist/lib/source/metadata');
 const Parser = require('../dist/lib/source/metadata/parser');
 const Util = require('../dist/lib/source/metadata/util');
 
-describe('Metadata source plugin', function _() {
+describe('Metadata source plugin', function() {
   const metadataPaths = require('./data/metadata-paths.json');
   const metadataValues = require('./data/metadata-values.json');
 
-  it('traverses metadata paths', function __(done) {
+  it('traverses metadata paths', function(done) {
     const data = Util.traverse('latest', Parser.paths, (path, cb) => cb(null, metadataPaths[path]));
 
     if (data.error) {
@@ -25,7 +25,7 @@ describe('Metadata source plugin', function _() {
     done();
   });
 
-  it('parses traversed values into a useful object', function __() {
+  it('parses traversed values into a useful object', function() {
     const parser = new Parser();
 
     parser.update(metadataValues);
@@ -75,7 +75,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it('periodically fetches metadata from the EC2 metadata API', function __(done) {
+  it('periodically fetches metadata from the EC2 metadata API', function(done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -15,17 +15,14 @@ describe('Metadata source plugin', function _() {
   const metadataValues = require('./data/metadata-values.json');
 
   it('traverses metadata paths', function __(done) {
-    Util.traverse('latest', Parser.paths,
-      (path, cb) => cb(null, metadataPaths[path]),
-      (err, data) => {
-        if (err) {
-          return done(err);
-        }
+    const data = Util.traverse('latest', Parser.paths, (path, cb) => cb(null, metadataPaths[path]));
 
-        expect(data).to.eql(metadataValues);
-        done();
-      }
-    );
+    if (data.error) {
+      return done(data.error);
+    }
+
+    expect(data.values).to.eql(metadataValues);
+    done();
   });
 
   it('parses traversed values into a useful object', function __() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,21 +161,28 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-aws-sdk-mock@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-1.2.0.tgz#08cde10694a0d6c12d1c61f9de8228b1efc2f254"
+aws-sdk-mock@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-1.7.0.tgz#7698b3ba82f493f71ff060ae2123cd0806ad8676"
   dependencies:
-    aws-sdk "^2.2.33"
+    aws-sdk "^2.3.0"
     sinon "^1.17.3"
     traverse "^0.6.6"
 
-aws-sdk@^2.2.33, aws-sdk@~2.2.28:
-  version "2.2.48"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.2.48.tgz#8e50899966554f6e5bd0e3e2955ebfd941ab7863"
+aws-sdk@^2.215.1, aws-sdk@^2.3.0:
+  version "2.215.1"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.215.1.tgz#e9837dd5a0c26ad3be99c9b41f4f5458f5a30b8f"
   dependencies:
-    sax "1.1.5"
-    xml2js "0.4.15"
-    xmlbuilder "2.6.2"
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.17"
+    xmlbuilder "4.2.1"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -784,6 +791,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+base64-js@^1.0.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
+
 basic-auth@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
@@ -839,6 +850,14 @@ browserslist@^2.1.2:
 buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -1502,6 +1521,10 @@ event-stream@~3.3.0:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -1956,6 +1979,14 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+
+ieee754@^1.1.4:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
+
 ignore-by-default@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -2223,6 +2254,10 @@ istanbul@~0.4.2:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
@@ -2455,10 +2490,6 @@ lodash@^4.0.0, lodash@^4.3.0, lodash@~4.11.1:
 lodash@^4.2.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.5.0.tgz#19bb3f4d51278f0b8c818ed145c74ecf9fe40e6d"
 
 log-driver@1.2.5:
   version "1.2.5"
@@ -2982,6 +3013,10 @@ ps-tree@^1.0.1:
   dependencies:
     event-stream "~3.3.0"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3005,6 +3040,10 @@ qs@~6.3.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
 randomatic@^1.1.3:
   version "1.1.6"
@@ -3315,7 +3354,11 @@ samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
 
-sax@1.1.5, sax@>=0.6.0:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+sax@>=0.6.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
 
@@ -3785,6 +3828,13 @@ update-notifier@0.5.0:
     semver-diff "^2.0.0"
     string-length "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
@@ -3808,6 +3858,10 @@ util-deprecate@~1.0.1:
 utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
+
+uuid@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 uuid@^2.0.1:
   version "2.0.3"
@@ -3937,20 +3991,21 @@ xdg-basedir@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-xml2js@0.4.15, xml2js@^0.4.4:
+xml2js@0.4.17:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
+xml2js@^0.4.4:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.15.tgz#95cd03ff2dd144ec28bc6273bf2b2890c581ad0c"
   dependencies:
     sax ">=0.6.0"
     xmlbuilder ">=2.4.6"
 
-xmlbuilder@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-2.6.2.tgz#f916f6d10d45dc171b1be2e6e673fb6e0cc35d0a"
-  dependencies:
-    lodash "~3.5.0"
-
-xmlbuilder@>=2.4.6, xmlbuilder@^4.0.0:
+xmlbuilder@4.2.1, xmlbuilder@>=2.4.6, xmlbuilder@^4.0.0, xmlbuilder@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
   dependencies:


### PR DESCRIPTION
One of the major difficulties we've had with Propsd is handling legacy complexity. This PR refactors `metadata/util`'s `traverse` function. Previously it relied heavily on `each` which was a bizarre state machine implementation that ultimately isn't required as the "parallelism" it touted wasn't actually used.

Now, instead of using `each`, we operate on an array in a `while` loop, `shift` the first element off, process it, and continue until the array is empty. In the case of additional paths we push them onto the end of the array. Because we're using a `while` loop and `shift`ing we don't have to worry about modifying the array during iteration (because we're not actually iterating.)

The PR also bumps the version of the aws-sdk and aws-sdk-mock because they're seriously old and outdated. It also reorganizes the `Metadata._fetch` function for readability.