### PR TITLE
PD-20473-separate-cache-for-previous-properties

### DIFF
--- a/src/lib/transformers/tokend-client.js
+++ b/src/lib/transformers/tokend-client.js
@@ -249,6 +249,10 @@ class TokendClient extends Source.Polling(TokendParser) {
         'Content-Length': Buffer.byteLength(content)
       }
     }, (res) => {
+      if (res.statusCode !== 200) {
+        callback(new Error("ERROR: Unable to decrypt secret"), null)
+      }
+
       res.setEncoding('utf8');
       res.on('data', (chunk) => {
         secret += chunk;

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -90,7 +90,7 @@ describe('Metadata source plugin', function _() {
     });
 
     const source = new Metadata({
-      interval: 1000
+      interval: 100
     });
 
     source.once('update', () => {
@@ -106,15 +106,15 @@ describe('Metadata source plugin', function _() {
       expect(source.properties.credentials).to.be.an('object');
       expect(source.properties.interface).to.be.an('object');
 
-      // source.once('noupdate', () => {
-      //   console.log('in here?');
-      //   expect(source.state).to.equal(Metadata.RUNNING);
-      //   source.shutdown();
+      source.once('noupdate', () => {
+        expect(source.state).to.equal(Metadata.RUNNING);
+        source.shutdown();
 
-      //   AWS.restore();
-      //   done();
-      // });
-      done();
+        AWS.restore();
+        done();
+      });
+      // source.shutdown();
+      // done();
     });
 
     // source.once('noupdate', () => {
@@ -151,7 +151,7 @@ describe('Metadata source plugin', function _() {
       // Currently used in our Index object.
       expect(source.properties['auto-scaling-group']).to.be.a('string');
       expect(source.properties['auto-scaling-group']).to.equal('my-cool-auto-scaling-group');
-
+      source.shutdown();
       AWS.restore();
       done();
     });

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -78,7 +78,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
+  it('periodically fetches metadata from the EC2 metadata API', function __(done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -114,17 +114,17 @@ describe('Metadata source plugin', function _() {
       //   AWS.restore();
       //   done();
       // });
-      // done();
-    });
-
-    source.once('noupdate', () => {
-      // console.log('in here?');
-      expect(source.state).to.equal(Metadata.RUNNING);
-      source.shutdown();
-
-      AWS.restore();
       done();
     });
+
+    // source.once('noupdate', () => {
+    //   // console.log('in here?');
+    //   expect(source.state).to.equal(Metadata.RUNNING);
+    //   source.shutdown();
+
+    //   AWS.restore();
+    //   done();
+    // });
 
     source.initialize();
   });

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -14,7 +14,7 @@ describe('Metadata source plugin', function _() {
   const metadataPaths = require('./data/metadata-paths.json');
   const metadataValues = require('./data/metadata-values.json');
 
-  it('traverses metadata paths', function __(done) {
+  it.only('traverses metadata paths', function __(done) {
     Util.traverse('latest', Parser.paths,
       (path, cb) => cb(null, metadataPaths[path]),
       (err, data) => {
@@ -28,7 +28,7 @@ describe('Metadata source plugin', function _() {
     );
   });
 
-  it('parses traversed values into a useful object', function __() {
+  it.only('parses traversed values into a useful object', function __() {
     const parser = new Parser();
 
     parser.update(metadataValues);
@@ -45,7 +45,7 @@ describe('Metadata source plugin', function _() {
     expect(parser.properties.interface).to.be.an('object');
   });
 
-  it('doesn\'t display values that are undefined', function () {
+  it.only('doesn\'t display values that are undefined', function () {
     const parser = new Parser();
     const deletedMetadataValues = Object.assign({}, metadataValues);
 
@@ -59,7 +59,7 @@ describe('Metadata source plugin', function _() {
     expect(parser.properties).to.not.have.property('region');
   });
 
-  it('handles errors from the AWS SDK gracefully by not exposing the property', function (done) {
+  it.only('handles errors from the AWS SDK gracefully by not exposing the property', function (done) {
     AWS.mock('MetadataService', 'request', (path, callback) => {
       callback(new Error('some error from the AWS SDK'), null);
     });
@@ -78,7 +78,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it('periodically fetches metadata from the EC2 metadata API', function __(done) {
+  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -145,7 +145,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it('only retrieves ASG data once', function(done) {
+  it.only('only retrieves ASG data once', function(done) {
     const asgSpy = sinon.spy();
 
     AWS.mock('MetadataService', 'request', (path, callback) => {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -114,17 +114,17 @@ describe('Metadata source plugin', function _() {
       //   AWS.restore();
       //   done();
       // });
-      // done();
-    });
-
-    source.once('noupdate', () => {
-      console.log('in here?');
-      // expect(source.state).to.equal(Metadata.RUNNING);
-      // source.shutdown();
-
-      AWS.restore();
       done();
     });
+
+    // source.once('noupdate', () => {
+    //   console.log('in here?');
+    //   // expect(source.state).to.equal(Metadata.RUNNING);
+    //   // source.shutdown();
+
+    //   AWS.restore();
+    //   done();
+    // });
 
     source.initialize();
   });

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -90,7 +90,7 @@ describe('Metadata source plugin', function _() {
     });
 
     const source = new Metadata({
-      interval: 100
+      interval: 1000
     });
 
     source.once('update', () => {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -95,7 +95,7 @@ describe('Metadata source plugin', function _() {
 
     source.once('update', () => {
       // Currently used in our Index object.
-      console.log('first');
+      // console.log('first');
       expect(source.properties.account).to.be.a('string');
       expect(source.properties.region).to.be.a('string');
       expect(source.properties['vpc-id']).to.be.a('string');
@@ -114,17 +114,17 @@ describe('Metadata source plugin', function _() {
       //   AWS.restore();
       //   done();
       // });
-      done();
+      // done();
     });
 
-    // source.once('noupdate', () => {
-    //   console.log('in here?');
-    //   // expect(source.state).to.equal(Metadata.RUNNING);
-    //   // source.shutdown();
+    source.once('noupdate', () => {
+      // console.log('in here?');
+      expect(source.state).to.equal(Metadata.RUNNING);
+      source.shutdown();
 
-    //   AWS.restore();
-    //   done();
-    // });
+      AWS.restore();
+      done();
+    });
 
     source.initialize();
   });
@@ -184,6 +184,7 @@ describe('Metadata source plugin', function _() {
 
     source.once('noupdate', () => {
       expect(asgSpy.calledOnce).to.be.true;
+      source.shutdown();
       AWS.restore();
       done();
     });

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -78,7 +78,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it.only('periodically fetches metadata from the EC2 metadata API', function (done) {
+  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method
@@ -105,13 +105,23 @@ describe('Metadata source plugin', function _() {
       expect(source.properties.credentials).to.be.an('object');
       expect(source.properties.interface).to.be.an('object');
 
-      source.once('noupdate', () => {
-        expect(source.state).to.equal(Metadata.RUNNING);
-        // source.shutdown();
+      // source.once('noupdate', () => {
+      //   console.log('in here?');
+      //   expect(source.state).to.equal(Metadata.RUNNING);
+      //   source.shutdown();
 
-        AWS.restore();
-        done();
-      });
+      //   AWS.restore();
+      //   done();
+      // });
+    });
+
+    source.once('noupdate', () => {
+      console.log('in here?');
+      expect(source.state).to.equal(Metadata.RUNNING);
+      source.shutdown();
+
+      AWS.restore();
+      done();
     });
 
     source.initialize();

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -78,7 +78,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it('periodically fetches metadata from the EC2 metadata API', function __(done) {
+  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -45,7 +45,7 @@ describe('Metadata source plugin', function _() {
     expect(parser.properties.interface).to.be.an('object');
   });
 
-  it('doesn\'t display values that are undefined', function() {
+  it('doesn\'t display values that are undefined', function () {
     const parser = new Parser();
     const deletedMetadataValues = Object.assign({}, metadataValues);
 
@@ -59,7 +59,7 @@ describe('Metadata source plugin', function _() {
     expect(parser.properties).to.not.have.property('region');
   });
 
-  it('handles errors from the AWS SDK gracefully by not exposing the property', function(done) {
+  it('handles errors from the AWS SDK gracefully by not exposing the property', function (done) {
     AWS.mock('MetadataService', 'request', (path, callback) => {
       callback(new Error('some error from the AWS SDK'), null);
     });
@@ -86,7 +86,7 @@ describe('Metadata source plugin', function _() {
       callback(null, metadataPaths[path]);
     });
     AWS.mock('AutoScaling', 'describeAutoScalingInstances', (params, callback) => {
-      callback(null, {AutoScalingInstances: []});
+      callback(null, { AutoScalingInstances: [] });
     });
 
     const source = new Metadata({
@@ -117,16 +117,18 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it('retrieves ASG info for the instance', function(done) {
+  it.only('retrieves ASG info for the instance', function (done) {
     this.timeout(2500);
 
     AWS.mock('MetadataService', 'request', (path, callback) => {
       callback(null, metadataPaths[path]);
     });
     AWS.mock('AutoScaling', 'describeAutoScalingInstances', (params, callback) => {
-      callback(null, {AutoScalingInstances: [{
-        AutoScalingGroupName: 'my-cool-auto-scaling-group'
-      }]});
+      callback(null, {
+        AutoScalingInstances: [{
+          AutoScalingGroupName: 'my-cool-auto-scaling-group'
+        }]
+      });
     });
 
     const source = new Metadata({
@@ -145,7 +147,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it.only('only retrieves ASG data once', function(done) {
+  it.only('only retrieves ASG data once', function (done) {
     const asgSpy = sinon.spy();
 
     AWS.mock('MetadataService', 'request', (path, callback) => {
@@ -153,9 +155,11 @@ describe('Metadata source plugin', function _() {
     });
     AWS.mock('AutoScaling', 'describeAutoScalingInstances', (params, callback) => {
       asgSpy();
-      callback(null, {AutoScalingInstances: [{
-        AutoScalingGroupName: 'my-cool-auto-scaling-group'
-      }]});
+      callback(null, {
+        AutoScalingInstances: [{
+          AutoScalingGroupName: 'my-cool-auto-scaling-group'
+        }]
+      });
     });
 
     const source = new Metadata({
@@ -175,7 +179,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it('handles ASG errors from the AWS SDK by not surfacing the auto-scaling-group property', function(done) {
+  it('handles ASG errors from the AWS SDK by not surfacing the auto-scaling-group property', function (done) {
     this.timeout(2500);
 
     AWS.mock('MetadataService', 'request', (path, callback) => {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -78,7 +78,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
+  it('periodically fetches metadata from the EC2 metadata API', function __(done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method
@@ -95,6 +95,7 @@ describe('Metadata source plugin', function _() {
 
     source.once('update', () => {
       // Currently used in our Index object.
+      console.log('first');
       expect(source.properties.account).to.be.a('string');
       expect(source.properties.region).to.be.a('string');
       expect(source.properties['vpc-id']).to.be.a('string');
@@ -113,7 +114,7 @@ describe('Metadata source plugin', function _() {
       //   AWS.restore();
       //   done();
       // });
-      done();
+      // done();
     });
 
     source.once('noupdate', () => {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -117,8 +117,8 @@ describe('Metadata source plugin', function _() {
 
     source.once('noupdate', () => {
       console.log('in here?');
-      expect(source.state).to.equal(Metadata.RUNNING);
-      source.shutdown();
+      // expect(source.state).to.equal(Metadata.RUNNING);
+      // source.shutdown();
 
       AWS.restore();
       done();

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -179,7 +179,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it('handles ASG errors from the AWS SDK by not surfacing the auto-scaling-group property', function (done) {
+  it.only('handles ASG errors from the AWS SDK by not surfacing the auto-scaling-group property', function (done) {
     this.timeout(2500);
 
     AWS.mock('MetadataService', 'request', (path, callback) => {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -218,6 +218,9 @@ describe('Metadata source plugin', function _() {
 });
 
 describe("testing", function() {
+  const metadataPaths = require('./data/metadata-paths.json');
+  const metadataValues = require('./data/metadata-values.json');
+
   it('periodically fetches metadata from the EC2 metadata API', function __(done) {
     this.timeout(2500);
 

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -14,6 +14,57 @@ describe('Metadata source plugin', function _() {
   const metadataPaths = require('./data/metadata-paths.json');
   const metadataValues = require('./data/metadata-values.json');
 
+  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
+    this.timeout(2500);
+
+    // Stub the AWS.MetadataService request method
+    AWS.mock('MetadataService', 'request', (path, callback) => {
+      callback(null, metadataPaths[path]);
+    });
+    AWS.mock('AutoScaling', 'describeAutoScalingInstances', (params, callback) => {
+      callback(null, { AutoScalingInstances: [] });
+    });
+
+    const source = new Metadata({
+      interval: 100
+    });
+
+    source.once('update', () => {
+      // Currently used in our Index object.
+      // console.log('first');
+      expect(source.properties.account).to.be.a('string');
+      expect(source.properties.region).to.be.a('string');
+      expect(source.properties['vpc-id']).to.be.a('string');
+      expect(source.properties['iam-role']).to.eq('fake-fake');
+      expect(source.properties['instance-id']).to.be.a('string');
+
+      expect(source.properties.identity).to.be.an('object');
+      expect(source.properties.credentials).to.be.an('object');
+      expect(source.properties.interface).to.be.an('object');
+
+      // source.once('noupdate', () => {
+      //   console.log('in here?');
+      //   expect(source.state).to.equal(Metadata.RUNNING);
+      //   source.shutdown();
+
+      //   AWS.restore();
+      //   done();
+      // });
+      // done();
+    });
+
+    source.once('noupdate', () => {
+      // console.log('in here?');
+      expect(source.state).to.equal(Metadata.RUNNING);
+      source.shutdown();
+
+      AWS.restore();
+      done();
+    });
+
+    source.initialize();
+  });
+
   it.only('traverses metadata paths', function __(done) {
     Util.traverse('latest', Parser.paths,
       (path, cb) => cb(null, metadataPaths[path]),

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -107,7 +107,7 @@ describe('Metadata source plugin', function _() {
 
       source.once('noupdate', () => {
         expect(source.state).to.equal(Metadata.RUNNING);
-        source.shutdown();
+        // source.shutdown();
 
         AWS.restore();
         done();

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -78,7 +78,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
+  it('periodically fetches metadata from the EC2 metadata API', function __(done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method
@@ -129,36 +129,6 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it.only('retrieves ASG info for the instance', function (done) {
-    this.timeout(2500);
-
-    AWS.mock('MetadataService', 'request', (path, callback) => {
-      callback(null, metadataPaths[path]);
-    });
-    AWS.mock('AutoScaling', 'describeAutoScalingInstances', (params, callback) => {
-      callback(null, {
-        AutoScalingInstances: [{
-          AutoScalingGroupName: 'my-cool-auto-scaling-group'
-        }]
-      });
-    });
-
-    const source = new Metadata({
-      interval: 100
-    });
-
-    source.once('update', () => {
-      // Currently used in our Index object.
-      expect(source.properties['auto-scaling-group']).to.be.a('string');
-      expect(source.properties['auto-scaling-group']).to.equal('my-cool-auto-scaling-group');
-
-      AWS.restore();
-      done();
-    });
-
-    source.initialize();
-  });
-
   it.only('only retrieves ASG data once', function (done) {
     const asgSpy = sinon.spy();
 
@@ -185,6 +155,36 @@ describe('Metadata source plugin', function _() {
     source.once('noupdate', () => {
       expect(asgSpy.calledOnce).to.be.true;
       source.shutdown();
+      AWS.restore();
+      done();
+    });
+
+    source.initialize();
+  });
+
+  it.only('retrieves ASG info for the instance', function (done) {
+    this.timeout(2500);
+
+    AWS.mock('MetadataService', 'request', (path, callback) => {
+      callback(null, metadataPaths[path]);
+    });
+    AWS.mock('AutoScaling', 'describeAutoScalingInstances', (params, callback) => {
+      callback(null, {
+        AutoScalingInstances: [{
+          AutoScalingGroupName: 'my-cool-auto-scaling-group'
+        }]
+      });
+    });
+
+    const source = new Metadata({
+      interval: 100
+    });
+
+    source.once('update', () => {
+      // Currently used in our Index object.
+      expect(source.properties['auto-scaling-group']).to.be.a('string');
+      expect(source.properties['auto-scaling-group']).to.equal('my-cool-auto-scaling-group');
+
       AWS.restore();
       done();
     });

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -113,6 +113,7 @@ describe('Metadata source plugin', function _() {
       //   AWS.restore();
       //   done();
       // });
+      done();
     });
 
     source.once('noupdate', () => {

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -78,7 +78,7 @@ describe('Metadata source plugin', function _() {
     source.initialize();
   });
 
-  it.only('periodically fetches metadata from the EC2 metadata API', function __(done) {
+  it.only('periodically fetches metadata from the EC2 metadata API', function (done) {
     this.timeout(2500);
 
     // Stub the AWS.MetadataService request method


### PR DESCRIPTION
## Description:
This pull request is created to update propsd to continuously hold previously encrypted properties when a S3 / KMS failure occurs. We have experienced encrypted properties being set to `null` when we're unable to communicate to KMS.

## Note:
Context:
- The tokend transformer creates a cache that gets cleared every 5 mins (this is default). When an encrypted property is successfully decrypted from tokend, propsd stores the plaintext secret in this cache, after 5 mins this cache gets cleared and then propsd makes calls to tokend to decrypt again, and this process repeats every 5 mins.

Race Condition:
- If the cache gets cleared, and propsd makes a call to tokend to decrypt an encrypted property but tokend responds back with a 400 status code (saying it's unable to decrypt the property), what value should I set for this encrypted property? Right now, it is set to null.

Implementation:
- The idea here is before we clear the cache, we should keep a copy of it (`previousProperties`). In the case of when tokend is unable to decrypt an encrypted property use what exists in `previousProperties` until we receive a successful response from tokend.

## Testing:
I tested this by spinning up a dummy instance, and modified the source code to have this implementation. Below are the test cases I have experimented with and the steps that I used to verify the output.

Test cases:
- Unable to access S3 bucket
    1. Logged onto the dummy instance, made a request to the `v1/conqueso` endpoint and was able to receive properties successfully (including encrypted properties)
    2. Removed the IAM inline policy (allowing access to the `config.core-0` bucket) that is attached to the IAM role of this dummy instance
    3. While tailing the propsd logs, we start to see logs with errors saying `Access Denied` about accessing the `config.core-0` bucket.
    4. While on the instance, made a request to the `v1/conqueso` endpoint and was able to receive properties successfully (including encrypted properties)
    5. Updated a property
    6. Added back the IAM inline policy in step 2
    7. While on the instance, made a request to the `v1/conqueso` endpoint and was able to receive properties successfully (including encrypted properties), and validated that the property I changed in step 5 was updated with the new value

- Unable to access KMS
    1. Logged onto the dummy instance, made a request to the `v1/conqueso` endpoint and was able to receive properties successfully (including encrypted properties)
    2. Removed the egress rule (0.0.0.0/0) from the sg that was attached to this dummy instance
    3. While tailing the tokend logs, we start to see logs with errors saying `Access Denied` about KMS.
    4. While on the instance, made a request to the `v1/conqueso` endpoint and was able to receive properties successfully (including encrypted properties)
    5. Updated a property
    6. Added back the egress rule in step 2
    7. While on the instance, made a request to the `v1/conqueso` endpoint and was able to receive properties successfully (including encrypted properties), and validated that the property I changed in step 5 was updated with the new value




