### PR TITLE
Update the propsd S3 client to enable the use of assumeRoleWithWebIdentity in EKS

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "walk": "~2.3.9"
   },
   "dependencies": {
-    "aws-sdk": "~2.2.28",
+    "aws-sdk": "~2.635.0",
     "babel-runtime": "^6.23.0",
     "clone": "~1.0.2",
     "consul": "~0.23.0",

--- a/src/lib/source/s3.js
+++ b/src/lib/source/s3.js
@@ -77,6 +77,8 @@ class S3 extends Source.Polling(S3Parser) { // eslint-disable-line new-cap
       config.region = Config.get('index:region');
     }
 
+    config.credentialProvider = new Aws.CredentialProviderChain()
+
     this.service = new Aws.S3(config);
   }
 


### PR DESCRIPTION
This PR is to update propsd to work with IRSA (IAM roles for ServiceAccounts) in EKS
This change:
- Updates the AWS-SDK to a compatible version
- Explicitly sets the S3 credentialProvider to use the default Credential Provider Chain

The setting of the credentialProvider should not be necessary, but was required during testing to correctly authenticate in AWS

This may require more sign-off before merging to master (using the branch myself)

Fixes https://github.com/rapid7/propsd/issues/276

Testing:
- Tested locally using the test [S3](https://github.com/rapid7/propsd/blob/master/test/bin/s3-server.js) and [metadata](https://github.com/rapid7/propsd/blob/master/test/bin/metadata-server) services
- Tested locally using a real S3 bucket (used the test metadata service as I was on a laptop)
- Tested in AWS in an EKS cluster using [kube2IAM](https://github.com/jtblin/kube2iam) (annotates the pod and re-routes requests via the worker node, essentially making the calls appear to come from the EC2 instance)
- Tested in AWS in an EKS cluster using [IRSA](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) (annotates the pod and uses a OIDC provider to grant the pod IAM permissions)