### PR TITLE
Updating the propsd health-check to reflect initialising state

### DIFF
--- a/src/lib/source/common.js
+++ b/src/lib/source/common.js
@@ -123,6 +123,13 @@ class Source extends EventEmitter {
     return this.state !== Source.ERROR && this.state !== Source.WARNING;
   }
 
+  /**
+   * Ready States are anything but INITIALIZED or CREATED
+   */
+  get ready() {
+    return this.state !== Source.INITIALIZING && this.state !== Source.CREATED
+  }
+
   /* eslint-disable max-statements */
 
   /**

--- a/src/lib/sources.js
+++ b/src/lib/sources.js
@@ -167,6 +167,11 @@ class Sources extends EventEmitter {
       // TODO This logic is fairly ham-fisted right now. It'll work because nothing
       // is setting `state` to WARNING at the moment. When we do start supporting a
       // WARNING state, this will have to become aware that OK < WARING < ERROR.
+      if (!source.ready) {
+        object.code = STATUS_CODES.SERVICE_UNAVAILABLE;
+        object.status = source.state;
+      }
+
       if (!source.ok) {
         object.code = STATUS_CODES.INTERNAL_SERVER_ERROR;
         object.status = source.state;

--- a/src/lib/sources.js
+++ b/src/lib/sources.js
@@ -182,7 +182,7 @@ class Sources extends EventEmitter {
       }
 
       if (!source.ok) {
-        source_state.index.push(source.state)
+        source_state.source.push(source.state)
         source_state.count = source_state.count + 1
       }
 
@@ -191,7 +191,7 @@ class Sources extends EventEmitter {
 
     if (object.sources.length == source_state.count) {
       object.code = STATUS_CODES.INTERNAL_SERVER_ERROR;
-      object.status = source_state.index;
+      object.status = source_state.source;
     }
 
     return object;

--- a/src/lib/sources.js
+++ b/src/lib/sources.js
@@ -158,6 +158,11 @@ class Sources extends EventEmitter {
       status: 'OK'
     };
 
+    const source_state = {
+      source: [],
+      count: 0
+    }
+
     object.indices = this.indices.map((source) => {
       // TODO This logic is fairly ham-fisted right now. It'll work because nothing
       // is setting `state` to WARNING at the moment. When we do start supporting a
@@ -171,13 +176,23 @@ class Sources extends EventEmitter {
     });
 
     object.sources = this.properties.sources.map((source) => {
-      if (!source.ok) {
-        object.code = STATUS_CODES.INTERNAL_SERVER_ERROR;
+      if (!source.ready) {
+        object.code = STATUS_CODES.SERVICE_UNAVAILABLE;
         object.status = source.state;
+      }
+
+      if (!source.ok) {
+        source_state.index.push(source.state)
+        source_state.count = source_state.count + 1
       }
 
       return source.status();
     });
+
+    if (object.sources.length == source_state.count) {
+      object.code = STATUS_CODES.INTERNAL_SERVER_ERROR;
+      object.status = source_state.index;
+    }
 
     return object;
   }

--- a/src/lib/sources.js
+++ b/src/lib/sources.js
@@ -191,7 +191,7 @@ class Sources extends EventEmitter {
 
     if (object.sources.length == source_state.count) {
       object.code = STATUS_CODES.INTERNAL_SERVER_ERROR;
-      object.status = source_state.source;
+      object.status = source_state.source[source_state.count - 1];
     }
 
     return object;

--- a/src/lib/sources.js
+++ b/src/lib/sources.js
@@ -161,7 +161,7 @@ class Sources extends EventEmitter {
     const source_state = {
       source: [],
       count: 0
-    }
+    };
 
     object.indices = this.indices.map((source) => {
       // TODO This logic is fairly ham-fisted right now. It'll work because nothing
@@ -182,14 +182,14 @@ class Sources extends EventEmitter {
       }
 
       if (!source.ok) {
-        source_state.source.push(source.state)
-        source_state.count = source_state.count + 1
+        source_state.source.push(source.state);
+        source_state.count = source_state.count + 1;
       }
 
       return source.status();
     });
 
-    if (object.sources.length == source_state.count) {
+    if (object.sources.length === source_state.count) {
       object.code = STATUS_CODES.INTERNAL_SERVER_ERROR;
       object.status = source_state.source[source_state.count - 1];
     }

--- a/test/core-api-v1.js
+++ b/test/core-api-v1.js
@@ -4,8 +4,8 @@ const request = require('supertest');
 const Properties = require('../dist/lib/properties');
 const Sources = require('../dist/lib/sources');
 const S3 = require('../dist/lib/source/s3');
-global.Config = require('nconf')
 
+require('./lib/helpers');
 require('should');
 
 const testServerPort = 3000;

--- a/test/core-api-v1.js
+++ b/test/core-api-v1.js
@@ -4,6 +4,7 @@ const request = require('supertest');
 const Properties = require('../dist/lib/properties');
 const Sources = require('../dist/lib/sources');
 const S3 = require('../dist/lib/source/s3');
+global.Config = require('nconf')
 
 require('should');
 

--- a/test/core-api-v1.js
+++ b/test/core-api-v1.js
@@ -192,7 +192,7 @@ const makeServer = () => {
   return app.listen(testServerPort);
 };
 
-describe('Core API v1', () => {
+describe('Core API v1', function() {
   let server = null;
 
   beforeEach(() => {
@@ -213,7 +213,7 @@ describe('Core API v1', () => {
         .get(endpoints[endpoint])
         .set('Accept', 'application/json')
         .expect('Content-Type', 'application/json; charset=utf-8')
-        .expect(HTTP_OK)
+        .expect(HTTP_SERVICE_UNAVAILABLE)
         .end(done);
     });
 

--- a/test/core-api-v1.js
+++ b/test/core-api-v1.js
@@ -11,14 +11,16 @@ require('should');
 const testServerPort = 3000;
 const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+const HTTP_SERVICE_UNAVAILABLE = 503;
 
 const endpoints = {
   health: '/v1/health',
   status: '/v1/status'
 };
 
-const expectedStatusResponse = {
-  status: HTTP_OK,
+const expectedInitialStatusResponse = {
+  status: HTTP_SERVICE_UNAVAILABLE,
   index: {
     ok: true,
     updated: null,
@@ -58,6 +60,100 @@ const expectedStatusResponse = {
     updated: null,
     etag: null,
     state: 'CREATED',
+    resource: 's3://test-bucket/foo-quiz-buzz.json',
+    ok: true,
+    interval: 60000
+  }]
+};
+
+const expectedRunningStatusResponse = {
+  status: HTTP_OK,
+  index: {
+    ok: true,
+    updated: null,
+    interval: 60000,
+    running: true,
+    etag: null,
+    state: 'RUNNING',
+    resource: 's3://test-bucket/index.json',
+    name: 'index.json',
+    type: 's3'
+  },
+  indices: [{
+    ok: true,
+    updated: null,
+    interval: 60000,
+    running: true,
+    etag: null,
+    state: 'RUNNING',
+    resource: 's3://test-bucket/index.json',
+    name: 'index.json',
+    type: 's3'
+  }],
+  sources: [{
+    name: 'foo-bar-baz.json',
+    type: 's3',
+    status: 'okay',
+    updated: null,
+    etag: null,
+    state: 'RUNNING',
+    resource: 's3://test-bucket/foo-bar-baz.json',
+    ok: true,
+    interval: 60000
+  }, {
+    name: 'foo-quiz-buzz.json',
+    type: 's3',
+    status: 'okay',
+    updated: null,
+    etag: null,
+    state: 'RUNNING',
+    resource: 's3://test-bucket/foo-quiz-buzz.json',
+    ok: true,
+    interval: 60000
+  }]
+};
+
+const expectedIndexErrorStatusResponse = {
+  status: HTTP_INTERNAL_SERVER_ERROR,
+  index: {
+    ok: false,
+    updated: null,
+    interval: 60000,
+    running: true,
+    etag: null,
+    state: 'ERROR',
+    resource: 's3://test-bucket/index.json',
+    name: 'index.json',
+    type: 's3'
+  },
+  indices: [{
+    ok: false,
+    updated: null,
+    interval: 60000,
+    running: true,
+    etag: null,
+    state: 'ERROR',
+    resource: 's3://test-bucket/index.json',
+    name: 'index.json',
+    type: 's3'
+  }],
+  sources: [{
+    name: 'foo-bar-baz.json',
+    type: 's3',
+    status: 'okay',
+    updated: null,
+    etag: null,
+    state: 'RUNNING',
+    resource: 's3://test-bucket/foo-bar-baz.json',
+    ok: true,
+    interval: 60000
+  }, {
+    name: 'foo-quiz-buzz.json',
+    type: 's3',
+    status: 'okay',
+    updated: null,
+    etag: null,
+    state: 'RUNNING',
     resource: 's3://test-bucket/foo-quiz-buzz.json',
     ok: true,
     interval: 60000

--- a/test/sources.js
+++ b/test/sources.js
@@ -355,6 +355,7 @@ describe('Sources', function() {
   });
 
   describe('Health', function() {
+    this.timeout(3000);
     let stubs = null;
 
     beforeEach(function() {
@@ -363,8 +364,6 @@ describe('Sources', function() {
     });
 
     it('sets a healthy code and status message when index and sources are in ready state', function() {
-      stubs.sources.initialize();
-
       return stubs.sources.initialize().then(() => {
         expect(stubs.index.state).to.equal(Source.RUNNING);
 

--- a/test/sources.js
+++ b/test/sources.js
@@ -355,7 +355,6 @@ describe('Sources', function() {
   });
 
   describe('Health', function() {
-    this.timeout(5000);
     let stubs = null;
 
     beforeEach(function() {


### PR DESCRIPTION
This change is to modify the propsd health-check.
Currently, the health-check will return with a `200` unless a source or index is in `WARNING` or `ERROR` state
However, we have seen scenarios where the health-check will return `200` when sources are in an `INITIALIZING` or `CREATING` state
These states should return a not ready Status Code
Having some sources in an error state should not stop the service from being used, however having all in error should.

Worked on with @davepgreene 