### PR TITLE
PD-25634

### DIFF
--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -79,11 +79,16 @@ directory 'propsd-configuration-directory' do
   recursive true
 end
 
+# Use the default default, and if a node exists under propsd->config->overrides-><region>, use it
+region = node[:region] || node['region'] || node.region || nil
+config = node['propsd']['config']
+config = config.merge(config['overrides'][region]) if region && config['overrides'] && config['overrides'][region]
+
 template 'propsd-configuration' do
   path node['propsd']['paths']['configuration']
   source 'json.erb'
 
-  variables(:properties => node['propsd']['config'])
+  variables(:properties => config)
   notifies :restart, 'service[propsd]' if node['propsd']['enable']
 end
 


### PR DESCRIPTION
# Decription
Adding ability to override propsd bucket configuration based on region. 

Using the following chef environment config
```
"propsd": {
  "version": "<latest>",
  "config": {
    "index": {
      "bucket": "properties.prod-us.us-east-1.ops.com"
    },
    "overrides": {
      "eu-central-1": {
        "index": {
          "bucket": "properties.prod-eu.eu-central-1.ops.com"
        }    
      }
    }
  }
}
```
By default the bucket `properties.prod-us.us-east-1.ops.com` will be used to ensure backwards compatibility with existing deployments - if deployed in `eu-central-1`, the bucket `properties.prod-eu.eu-central-1.ops.com` will be used.

# Testing
Tested on canary instance:
* Verified original configuration worked (no `overrides` node)
* Verified additional `overrides` configuration worked